### PR TITLE
Date/time inputs do not work

### DIFF
--- a/lib/formtastic-bootstrap/inputs/base/timeish.rb
+++ b/lib/formtastic-bootstrap/inputs/base/timeish.rb
@@ -26,7 +26,7 @@ module FormtasticBootstrap
         
         def fragment_input_html(fragment, klass)
           opts = input_options.merge(:prefix => object_name, :field_name => fragment_name(fragment), :default => value, :include_blank => include_blank?)
-          template.send(:"text_field_#{fragment}", value, opts, input_html_options.merge(:id => fragment_id(fragment), :class => klass))
+          template.send(:text_field, value, opts, input_html_options.merge(:id => fragment_id(fragment), :class => klass))
         end
      
       end


### PR DESCRIPTION
Thanks a lot for this awesome plugin! It helps a lot with using formtastic alongside bootstrap.

However, I encountered a problem with datetime inputs. To me, it looks like a search and replace error: You might have simply changed formtastic's select to text_field. But formtastic dynamically decides whether to use select_date, select_time or select_datetime, while in your use case, only a simple text_field is needed.

Formtastic simply appends the appropriate postfix to "select". Appending the same thing to "text_field" results in NoMethodErrors.

I made a quick fix that you might or might not want to pull. In any case, I would love to see this issue resolved.

Sorry for not including test cases. I got dozens of error messages running the specs (probably an incompatibility with the version of formtastic I checked out) and I gave up on fixing this. Maybe adjusting the Gemfile to not point to a local path for formtastic could help.

Keep up the good work!
