### PR TITLE
Hidden inputs are still visible

### DIFF
--- a/lib/formtastic-bootstrap/inputs/hidden_input.rb
+++ b/lib/formtastic-bootstrap/inputs/hidden_input.rb
@@ -3,9 +3,7 @@ module FormtasticBootstrap
     class HiddenInput < Formtastic::Inputs::HiddenInput
       include Base
       def to_html
-        generic_input_wrapping do
-          builder.hidden_field(method, input_html_options)
-        end
+        builder.hidden_field(method, input_html_options)
       end
     end
   end


### PR DESCRIPTION
Prior to this change, specifying a field to be `:as => :hidden` would show a label for the hidden field.
