### PR TITLE
Remove reference to disabled inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ If you're filing a bug, thank you!  Secondly, in the report please include:
 * :datetime, :date, :time
  * As rich functionally as their Rails counterparts.
  * Extract into a standalone gem.
-* Disabled inputs
 * Tests
  * Refactor
  * More -- See if I'm making sure the Bootstrap classes are present.


### PR DESCRIPTION
Disabled and readonly inputs work with :input_html => { :disabled => true (or) :readonly => true }, just as they do in Formtastic.
