### PR TITLE
add a name attribute to timeish inputs

### DIFF
--- a/lib/formtastic-bootstrap/inputs/base/timeish.rb
+++ b/lib/formtastic-bootstrap/inputs/base/timeish.rb
@@ -17,18 +17,17 @@ module FormtasticBootstrap
         def time_input_html
           fragment_input_html(:time, "mini")
         end
-        
+
         def fragment_id(fragment)
           # TODO is this right?
-          # "#{input_html_options[:id]}_#{position(fragment)}i"
-          "#{input_html_options[:id]}[#{fragment}]"
+          "#{input_html_options[:id]}_#{position(fragment)}i"
         end
-        
+
         def fragment_input_html(fragment, klass)
           opts = input_options.merge(:prefix => object_name, :field_name => fragment_name(fragment), :default => value, :include_blank => include_blank?)
-          template.send(:"text_field_#{fragment}", value, opts, input_html_options.merge(:id => fragment_id(fragment), :class => klass))
+          template.send(:"text_field_#{fragment}", value, opts, input_html_options.merge(:id => fragment_id(fragment), :class => klass, :name=>"#{object_name}[#{method}]"))
         end
-     
+
       end
     end
   end


### PR DESCRIPTION
this might not be the correct way to do it (and might even be a hack masking another bug. i haven't investigated enough to know), but the timeish inputs currently generate a blank name attribute, and need a name attribute to work at all... this works afaics
