### PR TITLE
Updating classes on form elements for latest version of Twitter bootstrap

### DIFF
--- a/lib/formtastic-bootstrap/helpers/buttons_helper.rb
+++ b/lib/formtastic-bootstrap/helpers/buttons_helper.rb
@@ -7,7 +7,7 @@ module FormtasticBootstrap
       def buttons(*args, &block)
 
         html_options = args.extract_options!
-        html_options[:class] ||= "actions"
+        html_options[:class] ||= "form-actions"
   
         if html_options.has_key?(:name)
           ActiveSupport::Deprecation.warn('The :name option is not supported')
@@ -35,7 +35,7 @@ module FormtasticBootstrap
                 Formtastic::I18n.t(commit_button_i18n_key, :model => commit_button_object_name)) unless text.is_a?(::String)
       
         button_html = options.delete(:button_html) || {}
-        button_html.merge!(:class => [button_html[:class], "btn commit", commit_button_i18n_key].compact.join(' '))
+        button_html.merge!(:class => [button_html[:class], "btn btn-primary commit", commit_button_i18n_key].compact.join(' '))
       
         # TODO We don't have a wrapper. Add deprecation message.
         # wrapper_html = options.delete(:wrapper_html) || {}

--- a/lib/formtastic-bootstrap/inputs/base/wrapping.rb
+++ b/lib/formtastic-bootstrap/inputs/base/wrapping.rb
@@ -43,7 +43,7 @@ module FormtasticBootstrap
           opts[:class] ||= []
           opts[:class] = [opts[:class].to_s] unless opts[:class].is_a?(Array)
           opts[:class] << as
-          opts[:class] << "clearfix"
+          opts[:class] << "clearfix control-group"
           # opts[:class] << "input"
           opts[:class] << "error" if errors?
           opts[:class] << "optional" if optional?

--- a/spec/helpers/buttons_helper_spec.rb
+++ b/spec/helpers/buttons_helper_spec.rb
@@ -23,19 +23,19 @@ describe 'Formtastic::FormBuilder#buttons' do
       end
 
       it 'should render a div inside the form, with a class of "actions"' do
-        output_buffer.should have_tag("form div.actions")
+        output_buffer.should have_tag("form div.form-actions")
       end
 
       it 'should not render an ol inside the div' do
-        output_buffer.should_not have_tag("form div.actions ol")
+        output_buffer.should_not have_tag("form div.form-actions ol")
       end
 
       it 'should render the contents of the block inside the input' do
-        output_buffer.should have_tag("form div.actions", /hello/)
+        output_buffer.should have_tag("form div.form-actions", /hello/)
       end
 
       it 'should not render a legend inside the div' do
-        output_buffer.should_not have_tag("form div.actions legend")
+        output_buffer.should_not have_tag("form div.form-actions legend")
       end
     end
 
@@ -72,21 +72,20 @@ describe 'Formtastic::FormBuilder#buttons' do
       end
 
       it 'should render a "actions" div inside the form' do
-        output_buffer.should have_tag('form div.actions')
+        output_buffer.should have_tag('form div.form-actions')
       end
 
       it 'should not render a legend in the div' do
-        output_buffer.should_not have_tag('form div.actions legend')
+        output_buffer.should_not have_tag('form div.form-actions legend')
       end
 
       it 'should render an button item in the ol for each default button' do
-        output_buffer.should have_tag('form div.actions input.btn', :count => 1)
+        output_buffer.should have_tag('form div.form-actions input.btn', :count => 1)
       end
 
       it 'should render a commit list item for the commit button' do
-        output_buffer.should have_tag('form div.actions input.commit')
+        output_buffer.should have_tag('form div.form-actions input.commit')
       end
-
     end
 
     describe 'with button names as args' do
@@ -98,8 +97,8 @@ describe 'Formtastic::FormBuilder#buttons' do
       end
 
       it 'should render a form with a div containing an input for each button arg' do
-        output_buffer.should have_tag('form > div.actions > input', :count => 1)
-        output_buffer.should have_tag('form > div.actions > input.commit')
+        output_buffer.should have_tag('form > div.form-actions > input', :count => 1)
+        output_buffer.should have_tag('form > div.form-actions > input.commit')
       end
 
     end
@@ -133,12 +132,12 @@ describe 'Formtastic::FormBuilder#buttons' do
       end
   
       it 'should render a form with a div containing a input for each button arg' do
-        output_buffer.should have_tag('form > div.actions > input', :count => 1)
-        output_buffer.should have_tag('form > div.actions > input.commit', :count => 1)
+        output_buffer.should have_tag('form > div.form-actions > input', :count => 1)
+        output_buffer.should have_tag('form > div.form-actions > input.commit', :count => 1)
       end
   
       it 'should pass the options down to the div' do
-        output_buffer.should have_tag('form > div#my-id.actions')
+        output_buffer.should have_tag('form > div#my-id.form-actions')
       end
   
     end

--- a/spec/inputs/boolean_input_spec.rb
+++ b/spec/inputs/boolean_input_spec.rb
@@ -17,6 +17,7 @@ describe 'boolean input' do
 
   it_should_have_input_wrapper_with_class("boolean")
   it_should_have_input_wrapper_with_class(:clearfix)
+  it_should_have_input_wrapper_with_class("control-group")
   it_should_have_input_class_in_the_right_place
   it_should_have_input_wrapper_with_id("post_allow_comments_input")
   it_should_apply_error_logic_for_input_type(:boolean, :block)

--- a/spec/inputs/check_boxes_input_spec.rb
+++ b/spec/inputs/check_boxes_input_spec.rb
@@ -18,6 +18,7 @@ describe 'check_boxes input' do
 
     it_should_have_input_wrapper_with_class("check_boxes")
     it_should_have_input_wrapper_with_class(:clearfix)
+    it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_class_in_the_right_place
     it_should_have_input_wrapper_with_id("author_posts_input")
     it_should_have_a_nested_div

--- a/spec/inputs/date_input_spec.rb
+++ b/spec/inputs/date_input_spec.rb
@@ -22,6 +22,7 @@ describe 'date input' do
 
     it_should_have_input_wrapper_with_class("date")
     it_should_have_input_wrapper_with_class(:clearfix)
+    it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_wrapper_with_class(:stringish)
     it_should_have_input_class_in_the_right_place
     it_should_have_input_wrapper_with_id("post_publish_at_input")

--- a/spec/inputs/datetime_input_spec.rb
+++ b/spec/inputs/datetime_input_spec.rb
@@ -23,6 +23,7 @@ describe 'datetime input' do
 
     it_should_have_input_wrapper_with_class("datetime")
     it_should_have_input_wrapper_with_class(:clearfix)
+    it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_wrapper_with_class(:stringish) # Decide about this.
     it_should_have_input_class_in_the_right_place
     it_should_have_input_wrapper_with_id("post_publish_at_input")

--- a/spec/inputs/email_input_spec.rb
+++ b/spec/inputs/email_input_spec.rb
@@ -20,6 +20,7 @@ describe 'email input' do
 
     it_should_have_input_wrapper_with_class(:email)
     it_should_have_input_wrapper_with_class(:clearfix)
+    it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_wrapper_with_class(:stringish)
     it_should_have_input_class_in_the_right_place
     it_should_have_input_wrapper_with_id("post_email_input")

--- a/spec/inputs/file_input_spec.rb
+++ b/spec/inputs/file_input_spec.rb
@@ -17,6 +17,7 @@ describe 'file input' do
 
   it_should_have_input_wrapper_with_class("file")
   it_should_have_input_wrapper_with_class(:clearfix)
+  it_should_have_input_wrapper_with_class("control-group")
   it_should_have_input_class_in_the_right_place
   it_should_have_input_wrapper_with_id("post_body_input")
   it_should_have_label_with_text(/Body/)

--- a/spec/inputs/hidden_input_spec.rb
+++ b/spec/inputs/hidden_input_spec.rb
@@ -21,6 +21,7 @@ describe 'hidden input' do
 
   it_should_have_input_wrapper_with_class("hidden")
   it_should_have_input_wrapper_with_class(:clearfix)
+  it_should_have_input_wrapper_with_class("control-group")
   it_should_have_input_class_in_the_right_place
   it_should_have_input_wrapper_with_id("post_secret_input")
   it_should_not_have_a_label

--- a/spec/inputs/number_input_spec.rb
+++ b/spec/inputs/number_input_spec.rb
@@ -27,6 +27,7 @@ describe 'number input' do
 
     it_should_have_input_wrapper_with_class(:number)
     it_should_have_input_wrapper_with_class(:clearfix)
+    it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_wrapper_with_class(:stringish)
     it_should_have_input_class_in_the_right_place
     it_should_have_input_wrapper_with_id("post_title_input")

--- a/spec/inputs/password_input_spec.rb
+++ b/spec/inputs/password_input_spec.rb
@@ -17,6 +17,7 @@ describe 'password input' do
 
   it_should_have_input_wrapper_with_class(:password)
   it_should_have_input_wrapper_with_class(:clearfix)
+  it_should_have_input_wrapper_with_class("control-group")
   it_should_have_input_wrapper_with_class(:stringish)
   it_should_have_input_class_in_the_right_place
   it_should_have_input_wrapper_with_id("post_title_input")

--- a/spec/inputs/phone_input_spec.rb
+++ b/spec/inputs/phone_input_spec.rb
@@ -20,6 +20,7 @@ describe 'phone input' do
 
     it_should_have_input_wrapper_with_class(:phone)
     it_should_have_input_wrapper_with_class(:clearfix)
+    it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_wrapper_with_class(:stringish)
     it_should_have_input_class_in_the_right_place
     it_should_have_input_wrapper_with_id("post_phone_input")

--- a/spec/inputs/radio_input_spec.rb
+++ b/spec/inputs/radio_input_spec.rb
@@ -20,6 +20,7 @@ describe 'radio input' do
 
     it_should_have_input_wrapper_with_class("radio")
     it_should_have_input_wrapper_with_class(:clearfix)
+    it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_class_in_the_right_place
     it_should_have_input_wrapper_with_id("post_author_input")
     it_should_have_a_nested_div

--- a/spec/inputs/range_input_spec.rb
+++ b/spec/inputs/range_input_spec.rb
@@ -21,6 +21,7 @@ describe 'range input' do
 
     it_should_have_input_wrapper_with_class(:range)
     it_should_have_input_wrapper_with_class(:clearfix)
+    it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_wrapper_with_class(:stringish) # might be removed
     it_should_have_input_class_in_the_right_place
     it_should_have_input_wrapper_with_id("author_age_input")

--- a/spec/inputs/search_input_spec.rb
+++ b/spec/inputs/search_input_spec.rb
@@ -20,6 +20,7 @@ describe 'search input' do
 
     it_should_have_input_wrapper_with_class(:search)
     it_should_have_input_wrapper_with_class(:clearfix)
+    it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_wrapper_with_class(:stringish)
     it_should_have_input_class_in_the_right_place
     it_should_have_input_wrapper_with_id("post_search_input")

--- a/spec/inputs/string_input_spec.rb
+++ b/spec/inputs/string_input_spec.rb
@@ -20,6 +20,7 @@ describe 'string input' do
 
     it_should_have_input_wrapper_with_class(:string)
     it_should_have_input_wrapper_with_class(:clearfix)
+    it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_wrapper_with_class(:stringish)
     it_should_have_input_class_in_the_right_place
     it_should_have_input_wrapper_with_id("post_title_input")

--- a/spec/inputs/text_input_spec.rb
+++ b/spec/inputs/text_input_spec.rb
@@ -17,6 +17,7 @@ describe 'text input' do
 
   it_should_have_input_wrapper_with_class("text")
   it_should_have_input_wrapper_with_class(:clearfix)
+  it_should_have_input_wrapper_with_class("control-group")
   it_should_have_input_class_in_the_right_place
   it_should_have_input_wrapper_with_id("post_body_input")
   it_should_have_label_with_text(/Body/)

--- a/spec/inputs/time_input_spec.rb
+++ b/spec/inputs/time_input_spec.rb
@@ -70,6 +70,7 @@ describe 'time input' do
 
       it_should_have_input_wrapper_with_class("time")
       it_should_have_input_wrapper_with_class(:clearfix)
+      it_should_have_input_wrapper_with_class("control-group")
       it_should_have_input_wrapper_with_class(:stringish)
       it_should_have_input_class_in_the_right_place
       it_should_have_input_wrapper_with_id("post_publish_at_input")

--- a/spec/inputs/time_zone_input_spec.rb
+++ b/spec/inputs/time_zone_input_spec.rb
@@ -17,6 +17,7 @@ describe 'time_zone input' do
 
   it_should_have_input_wrapper_with_class("time_zone")
   it_should_have_input_wrapper_with_class(:clearfix)
+  it_should_have_input_wrapper_with_class("control-group")
   it_should_have_input_wrapper_with_id("post_time_zone_input")
   it_should_apply_error_logic_for_input_type(:time_zone)
 

--- a/spec/inputs/url_input_spec.rb
+++ b/spec/inputs/url_input_spec.rb
@@ -20,6 +20,7 @@ describe 'url input' do
 
     it_should_have_input_wrapper_with_class(:url)
     it_should_have_input_wrapper_with_class(:clearfix)
+    it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_wrapper_with_class(:stringish)
     it_should_have_input_class_in_the_right_place
     it_should_have_input_wrapper_with_id("post_url_input")


### PR DESCRIPTION
Hey thanks for the great gem.  I've been trying to get forms to look decent with Twitter bootstrap.

A few things have changed with the most recent version of bootstrap... they now use 'control-group' around input fields and 'form-actions' instead of 'actions'.  I also added btn-primary on the form submit.
