### PR TITLE
Don't render hint if there are any errors.

### DIFF
--- a/lib/formtastic-bootstrap/inputs/base/hints.rb
+++ b/lib/formtastic-bootstrap/inputs/base/hints.rb
@@ -6,7 +6,7 @@ module FormtasticBootstrap
         include Formtastic::Inputs::Base::Hints
 
         def hint_html(inline_or_block = :inline)
-          if hint?
+          if hint? and !errors?
             hint_class = if inline_or_block == :inline
               options[:hint_class] || builder.default_inline_hint_class
             else


### PR DESCRIPTION
Otherwise there will be hint colored red after error messages. Which I think is useless in the case.
