### PR TITLE
Make it work with autocomplete

### DIFF
--- a/lib/formtastic-bootstrap/helpers/input_helper.rb
+++ b/lib/formtastic-bootstrap/helpers/input_helper.rb
@@ -2,11 +2,16 @@ module FormtasticBootstrap
   module Helpers
     module InputHelper
       include Formtastic::Helpers::InputHelper
-      
+
       def standard_input_class_name(as)
-        "FormtasticBootstrap::Inputs::#{as.to_s.camelize}Input"
+        full_name = "FormtasticBootstrap::Inputs::#{as.to_s.camelize}Input"
+        if FormtasticBootstrap::Inputs.const_defined? custom_input_class_name(as).to_sym
+          full_name
+        else
+          super as
+        end
       end
-      
+
     end
   end
 end


### PR DESCRIPTION
This solves issue #17

Formtastic falls back on to the Formtastic::Inputs module if it didn't find the input class in FormtasticBoostrap::Inputs.

This may not be the best way to solve the autocomplete issue but I need something working quickly. Another way would be to inject the FormtasticBooostrap module into rails3-jquery-autocomplete in place of the vanilla Formtastic module.
