### PR TITLE
Adding Appended Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,15 @@ To create a Prepended Text field, use the ```:prepend``` option.  This works on 
       <% end %>
     <% end %>
 
+#### Appended Text
+To create an Appended Text field, use the ```:append``` option.  This works on any text field input type, like ```:url```, ```:search```, and of course ```:string```
+
+    <%= semantic_form_for @user do |f| %>
+      <%= f.inputs do %>
+        <%= f.input :handle, :append => '%' %>
+      <% end %>
+    <% end %>
+
 ## Contributing
  
 ### Contributors

--- a/lib/formtastic-bootstrap/inputs/base/wrapping.rb
+++ b/lib/formtastic-bootstrap/inputs/base/wrapping.rb
@@ -13,6 +13,10 @@ module FormtasticBootstrap
                 prepended_input_wrapping do
                   [template.content_tag(:span, options[:prepend], :class => 'add-on'), yield, hint_html].join("\n").html_safe
                 end
+              elsif options[:append]
+                appended_input_wrapping do
+                  [yield, template.content_tag(:span, options[:append], :class => 'add-on'), hint_html].join("\n").html_safe
+                end
               else
                 [yield, hint_html].join("\n").html_safe
               end
@@ -46,6 +50,13 @@ module FormtasticBootstrap
         # Bootstrap prepend feature
         def prepended_input_wrapping(&block)
           template.content_tag(:div, :class => 'input-prepend') do
+            yield
+          end
+        end
+
+        # Bootstrap append feature
+        def appended_input_wrapping(&block)
+          template.content_tag(:div, :class => 'input-append') do
             yield
           end
         end


### PR DESCRIPTION
Bootstrap supports appended text as well prepended text. Currently this gem only supports prepended text. I have added in a minimal amount of code to support appended text. The code is based directly off the code already in place the prepended text. I have also updated the read me as well.
