### PR TITLE
Move help-inline error sentences inside their control's div

### DIFF
--- a/lib/formtastic-bootstrap/inputs/base/wrapping.rb
+++ b/lib/formtastic-bootstrap/inputs/base/wrapping.rb
@@ -22,13 +22,16 @@ module FormtasticBootstrap
 
         def control_group_wrapping(&block)
           template.content_tag(:div, 
-          [template.capture(&block), error_html].join("\n").html_safe, 
+            template.capture(&block).html_safe, 
             wrapper_html_options
           )
         end
 
         def controls_wrapping(&block)
-          template.content_tag(:div, template.capture(&block).html_safe, controls_wrapper_html_options)
+          template.content_tag(:div,
+            [template.capture(&block), error_html].join("\n").html_safe,
+            controls_wrapper_html_options
+          )
         end
         
         def controls_wrapper_html_options


### PR DESCRIPTION
Issue #42, move the help-inline items to inside their control's div.
Based on Twitter Bootstrap documentation
