### PR TITLE
Autoloading CountryInput

### DIFF
--- a/lib/formtastic-bootstrap/inputs.rb
+++ b/lib/formtastic-bootstrap/inputs.rb
@@ -5,7 +5,7 @@ module FormtasticBootstrap
     # autoload :Basic          
     autoload :BooleanInput,        "formtastic-bootstrap/inputs/boolean_input" 
     autoload :CheckBoxesInput,     "formtastic-bootstrap/inputs/check_boxes_input"
-    # autoload :CountryInput       # TODO Come back to this.
+    autoload :CountryInput,        "formtastic-bootstrap/inputs/country_input" 
     autoload :DateInput,           "formtastic-bootstrap/inputs/date_input" 
     # autoload :DatePickerInput    # TODO Come back to this.
     # autoload :DatetimePickerInput # TODO Come back to this.


### PR DESCRIPTION
Contributing to commit "Merge pull request #23 from nicholashubbard/master", the CountryInput was there, but I was receiving "Formtastic::UnknownInputError - Unable to find input class for country".

So, just autoloading the class CountryInput and it works now.
