### PR TITLE
The option :label_outside for boolean input not rendering input when sent to true

### DIFF
--- a/lib/formtastic-bootstrap/inputs/boolean_input.rb
+++ b/lib/formtastic-bootstrap/inputs/boolean_input.rb
@@ -2,11 +2,11 @@
 module FormtasticBootstrap
   module Inputs
     class BooleanInput < Formtastic::Inputs::BooleanInput
-      include Base      
-      
+      include Base
+
       def to_html
         control_group_wrapping do
-          options[:label_outside] ? control_label_html : "".html_safe <<
+          (options[:label_outside] ? control_label_html : "".html_safe) <<
           hidden_field_html <<
           controls_wrapping do
             label_with_nested_checkbox


### PR DESCRIPTION
A bug with precedence was causing only the label and not the input to be rendered when options[:label_outside] for boolean inputs was set to true.
