### PR TITLE
Fix lib glob pattern in gemspec.

### DIFF
--- a/formtastic-bootstrap.gemspec
+++ b/formtastic-bootstrap.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     "LICENSE.txt",
     "README.md",
     "VERSION",
-    "lib/**",
+    "lib/**/*",
     "vendor/assets/stylesheets/formtastic-bootstrap.css"
   ]
   s.licenses = ["MIT"]


### PR DESCRIPTION
Fixes GH #67 - formtastic-bootstrap gem release 2.1.0 does not include lib source files.
