### PR TITLE
Enable :hint for boolean inputs

### DIFF
--- a/lib/formtastic-bootstrap/inputs/boolean_input.rb
+++ b/lib/formtastic-bootstrap/inputs/boolean_input.rb
@@ -9,7 +9,7 @@ module FormtasticBootstrap
           (options[:label_outside] ? control_label_html : "".html_safe) <<
           hidden_field_html <<
           controls_wrapping do
-            label_with_nested_checkbox
+            [label_with_nested_checkbox, hint_html].join("\n").html_safe
           end
         end
       end

--- a/spec/inputs/boolean_input_spec.rb
+++ b/spec/inputs/boolean_input_spec.rb
@@ -153,6 +153,14 @@ describe 'boolean input' do
     output_buffer.should have_tag('form div.control-group div.controls label input[@type="checkbox"]')
     output_buffer.should have_tag('form div.control-group div.controls label input[@name="project[allow_comments]"]')
   end
+
+  it "should render hints" do
+    concat(semantic_form_for(@new_post) do |builder|
+      concat(builder.input(:allow_comments, :as => :boolean, :hint => 'Allow user to post comment'))
+    end)
+
+    output_buffer.should have_tag("form div.control-group div.controls span.help-block")
+  end
   
   context "when required" do
     


### PR DESCRIPTION
Hi,

In one of my project I've found the need of adding hint to boolean field (sounds weird, I know) but it seems like `:hint` doesn't work with boolean field and found out it's because boolean input field doesn't call `hint_html`. I've updated boolean input class and make it call `hint_html` in similar way to `bootstrap_wrapping` in this pull request.
