### PR TITLE
Fixes #59 : every fragment should be symbols

### DIFF
--- a/lib/formtastic-bootstrap/inputs/base/timeish.rb
+++ b/lib/formtastic-bootstrap/inputs/base/timeish.rb
@@ -9,7 +9,7 @@ module FormtasticBootstrap
             controls_wrapping do
               hidden_fragments <<
               fragments.map do |fragment|
-                fragment_input_html(fragment)
+                fragment_input_html(fragment.to_sym)
               end.join.html_safe
             end
           end


### PR DESCRIPTION
In Formastic, framengs in timeish.rb are defined by the concatenation of date_fragments + time_fragments 

``` ruby
def fragments
  date_fragments + time_fragments
end
```

Prior to this [commit](https://github.com/justinfrench/formtastic/commit/a22b424f12cb414e286eef03a0f09fb1e77bc4ba#lib/formtastic/inputs/base/timeish.rb), i18n_date_fragments was returning string and not symbols.

``` ruby
def i18n_date_fragments
  order = ::I18n.t(:order, :scope => [:date])
  order = nil unless order.is_a?(Array)
  order
end
```

In Formastic-bootstrap, to build a datetime, a list of fragments is defined only with symbols [timeish.rb](https://github.com/mjbellantoni/formtastic-bootstrap/blob/master/lib/formtastic-bootstrap/inputs/base/timeish.rb#L37) so fragments for time could not be found.

``` ruby
def fragment_class(fragment) 
  { 
    :year   => "span1", 
    :month  => "span2",
    :day    => "span1",
    :hour   => "span1",
    :minute => "span1",
    :second => "span1"
  }[fragment]
end
```

To avoid this, I converted every fragment of the list into symbols. It will make the trick until Formstatic release a new version with this commit listed above.

``` ruby
fragments.map do |fragment|
  fragment_input_html(fragment.to_sym)
```

Should solve this issue #59 
