### PR TITLE
Fix :wrapper_html :class and :button_html :class options

### DIFF
--- a/lib/formtastic-bootstrap/actions/base.rb
+++ b/lib/formtastic-bootstrap/actions/base.rb
@@ -4,17 +4,22 @@ module FormtasticBootstrap
 
       # Bootstrap doesn't have wrappers.
       def wrapper(&block)
-        # TODO Detect if user passed wrapper_html_options and issue
-        #      a warning that they're ignored. (See the original in
-        #      Formtastic.)
         template.capture(&block)
       end
 
+      # Default button class
+      def default_wrapper_classes
+        ["btn"]
+      end
+
+      # :wrapper_html member :class is prefixed with btn
+      # :button_html member :class is all encompassing
       def default_button_html
         {
           :accesskey => accesskey,
-          :class => "btn"
-        }
+          :class => wrapper_class.strip,
+          :id => wrapper_id
+         }
       end
 
     end


### PR DESCRIPTION
This appears to fix the options functionality retaining both :wrapper_html and :button_html options without actually wrapping the action in another tag.
Only tested with class and ensured that id also remains but not sure what it does with other options.

Default class is "btn"
:wrapper_html => { :class => "wrapper-option" } is prefixed with the default and results in class="btn wrapper-option"
:button_html => { :class => "button-option" } will specify the whole class value and results in class="button-option"

Tested all these definitions:

``` erb
    <%= f.actions do %>
        <%= f.action :submit, :as => :button, :button_html  => { :class => 'btn btn-primary' } %>
        <%= f.action :cancel, :as => :link,   :button_html  => { :class => 'btn btn-danger' } %>
        <%= f.action :reset,  :as => :input,  :button_html  => { :class => 'btn btn-warning' } %>
        <%= f.action :submit, :as => :button, :wrapper_html => { :class => 'btn-inverse' } %>
        <%= f.action :cancel, :as => :link,   :wrapper_html => { :class => 'btn-info' } %>
        <%= f.action :submit, :as => :input,  :wrapper_html => { :class => 'btn-link' } %>
        <%= f.action :submit, :as => :button  %>
        <%= f.action :cancel, :as => :link    %>
        <%= f.action :submit, :as => :input   %>
        <%= f.action :submit %>
        <%= f.action :cancel %>
        <%= f.action :reset  %>
    <% end %>
```

And found everything to be good.

nJoy!
