### PR TITLE
Date Select Placeholder: Initial fix to use more appropriate placeholders

### DIFF
--- a/lib/formtastic-bootstrap/inputs/base/timeish.rb
+++ b/lib/formtastic-bootstrap/inputs/base/timeish.rb
@@ -46,9 +46,15 @@ module FormtasticBootstrap
         end
 
         def fragment_placeholder(fragment)
-          "." + fragment_class(fragment)
+          {
+            :year   => "YYYY",
+            :month  => "MM",
+            :day    => "DD",
+            :hour   => "hh",
+            :minute => "mm",
+            :second => "ss"
+          }[fragment]
         end
-
       end
     end
   end


### PR DESCRIPTION
- Now using YYYY, MM, DD, hh, mm, ss instead of span1, span2, ...
- TODO: Add customizable placeholder
