### PR TITLE
Change close in alert from button to link so pressing enter in form stil...

### DIFF
--- a/lib/formtastic-bootstrap/helpers/errors_helper.rb
+++ b/lib/formtastic-bootstrap/helpers/errors_helper.rb
@@ -59,7 +59,7 @@ module FormtasticBootstrap
         end
 
         template.content_tag(:div, html_options) do
-          template.content_tag(:button, "&times;".html_safe, :class => "close", "data-dismiss" => "alert") +
+          template.content_tag(:a, "&times;".html_safe, :class => "close", "data-dismiss" => "alert") +
           template.content_tag(:ul, {:class => "error-list"}) do
             Formtastic::Util.html_safe(full_errors.map { |error| template.content_tag(:li, Formtastic::Util.html_safe(error)) }.join)
           end


### PR DESCRIPTION
...l submits the form

Right now if there are errors in your form with an alert at the top.  Pressing enter will not submit the form but close the alert.

If the button close is changed to a link it works as expected and the form submits on pressing enter
