### PR TITLE
Include error_html in bootstrap_wrapping

### DIFF
--- a/lib/formtastic-bootstrap/inputs/base/wrapping.rb
+++ b/lib/formtastic-bootstrap/inputs/base/wrapping.rb
@@ -12,7 +12,8 @@ module FormtasticBootstrap
             yield,
             add_on_content(options[:append]),
             options[:append_content],
-            hint_html
+            hint_html,
+            error_html
           ].compact.join("\n").html_safe
 
           form_group_wrapping do


### PR DESCRIPTION
It seems like the call to `error_html` that allows inline errors to be displayed was removed. This adds it back in.
