### PR TITLE
form-horizontal support for Bootstrap 3.x

### DIFF
--- a/lib/formtastic-bootstrap/inputs/base/labelling.rb
+++ b/lib/formtastic-bootstrap/inputs/base/labelling.rb
@@ -16,7 +16,13 @@ module FormtasticBootstrap
 
         # def control_label_html
         def label_html
-          render_label? ? builder.label(input_name, label_text, label_html_options) : "".html_safe
+          if render_label?
+            template.content_tag(:span, :class => 'form-label') do
+              builder.label(input_name, label_text, label_html_options)
+            end
+          else
+            "".html_safe
+          end
         end
 
       end

--- a/lib/formtastic-bootstrap/inputs/boolean_input.rb
+++ b/lib/formtastic-bootstrap/inputs/boolean_input.rb
@@ -5,7 +5,7 @@ module FormtasticBootstrap
       include Base
 
       def to_html
-        checkbox_wrapping do
+        bootstrap_wrapping do
           hidden_field_html <<
           "".html_safe <<
           [label_with_nested_checkbox, hint_html].join("\n").html_safe

--- a/lib/formtastic-bootstrap/inputs/check_boxes_input.rb
+++ b/lib/formtastic-bootstrap/inputs/check_boxes_input.rb
@@ -7,8 +7,7 @@ module FormtasticBootstrap
       # TODO Make sure help blocks work correctly.
 
       def to_html
-        form_group_wrapping do
-          label_html <<
+        bootstrap_wrapping do
           hidden_field_for_all << # Might need to remove this guy.
           collection.map { |choice|
             choice_html(choice)

--- a/lib/formtastic-bootstrap/inputs/radio_input.rb
+++ b/lib/formtastic-bootstrap/inputs/radio_input.rb
@@ -7,8 +7,7 @@ module FormtasticBootstrap
       # TODO Make sure help blocks work correctly.
 
       def to_html
-        form_group_wrapping do
-          label_html <<
+        bootstrap_wrapping do
           collection.map { |choice|
             choice_html(choice)
           }.join("\n").html_safe


### PR DESCRIPTION
It seems the form-group markup for horizontal forms [has been changed  in bootstrap 3.x](http://getbootstrap.com/css/#forms-horizontal ). Thus, the old way (#34) doesn't work any more.

[potenza/bootstrap_form](https://github.com/potenza/bootstrap_form) gem solved this by defining default class for `:left` and `:right` column in `#form_for` method. I think we could place it similarly but in `#inputs` method, like:
```rb
= f.inputs(label_class: 'col-sm-2', wrapper_class: 'col-sm-10')
```
and add some wrapper around the `input.control-group`, to make it look like this:
```html
<div class="form-group">
  <label class="col-sm-2">Foo</label>
  <div class="form-wrapper col-sm-10">
    <input type="text" name="foo" class="form-control" />
  </div>
</div>
```

Before this issue gets fixed, we could hack it ourselves with `label_html` and `input_html` options for now but.. there is no `label_html` options in current version of formtastic =( (see justinfrench/formtastic#865)

Some other ideas?