### PR TITLE
Remove css hacks in Timeish input

### DIFF
--- a/lib/formtastic-bootstrap/inputs/base/timeish.rb
+++ b/lib/formtastic-bootstrap/inputs/base/timeish.rb
@@ -2,52 +2,50 @@ module FormtasticBootstrap
   module Inputs
     module Base
       module Timeish
+        FRAGMENT_CLASSES = {
+          :year   => "col-xs-2",
+          :month  => "col-xs-3",
+          :day    => "col-xs-1",
+          :hour   => "col-xs-offset-3 col-xs-1",
+          :minute => "col-xs-1",
+          :second => "col-xs-1"
+        }
 
         def to_html
-          form_group_wrapping do
-            label_html <<
+          bootstrap_wrapping do
             hidden_fragments <<
-            form_control_row_wrapping do
+            row_wrapping do
               fragments.map do |fragment|
-                fragment_input_html(fragment.to_sym)
+                fragment_html(fragment.to_sym)
               end.join.html_safe
             end
           end
         end
 
-        def form_control_row_wrapping(&block)
+        def row_wrapping(&block)
           template.content_tag(:div,
             template.capture(&block).html_safe,
-            form_control_row_wrapper_html_options
+            :class => 'row'
           )
         end
 
-        def form_control_row_wrapper_html_options
-          { :class => "form-control" }
-        end
-
-        def fragment_input_html(fragment)
-          opts = input_options.merge(:prefix => fragment_prefix, :field_name => fragment_name(fragment), :default => value, :include_blank => include_blank?)
-          template.send(:"select_#{fragment}", value, opts, fragment_input_html_options(fragment))
+        def fragment_html(fragment)
+          template.content_tag(:div, :class => fragment_class(fragment)) do
+            opts = input_options.merge(:prefix => fragment_prefix, :field_name => fragment_name(fragment), :default => value, :include_blank => include_blank?)
+            template.send(:"select_#{fragment}", value, opts, fragment_input_html_options(fragment))
+          end
         end
 
         def fragment_input_html_options(fragment)
           input_html_options.tap do |options|
             options[:id] = fragment_id(fragment)
-            options[:class] = ((options[:class] || "").split << fragment_class(fragment)).join(" ")
+            options[:class] = ((options[:class] || "").split << "form-control").join(" ")
             options[:placeholder] = fragment_placeholder(fragment)
           end
         end
 
         def fragment_class(fragment)
-          {
-            :year   => "col-xs-1",
-            :month  => "col-xs-2",
-            :day    => "col-xs-1",
-            :hour   => "col-xs-1",
-            :minute => "col-xs-1",
-            :second => "col-xs-1"
-          }[fragment]
+          options[:fragment_classes] || self.class::FRAGMENT_CLASSES[fragment]
         end
 
         def fragment_placeholder(fragment)

--- a/lib/formtastic-bootstrap/inputs/date_select_input.rb
+++ b/lib/formtastic-bootstrap/inputs/date_select_input.rb
@@ -1,6 +1,12 @@
 module FormtasticBootstrap
   module Inputs
     class DateSelectInput < Formtastic::Inputs::DateSelectInput
+      FRAGMENT_CLASSES = {
+        :year   => "col-xs-4",
+        :month  => "col-xs-5",
+        :day    => "col-xs-3"
+      }
+
       include Base
       include Base::Timeish
     end

--- a/lib/formtastic-bootstrap/inputs/time_select_input.rb
+++ b/lib/formtastic-bootstrap/inputs/time_select_input.rb
@@ -1,6 +1,12 @@
 module FormtasticBootstrap
   module Inputs
     class TimeSelectInput < Formtastic::Inputs::TimeSelectInput
+      FRAGMENT_CLASSES = {
+        :hour    => "col-xs-4",
+        :minute  => "col-xs-4",
+        :secound => "col-xs-4"
+      }
+
       include Base
       include Base::Timeish
     end

--- a/vendor/assets/stylesheets/formtastic-bootstrap.css
+++ b/vendor/assets/stylesheets/formtastic-bootstrap.css
@@ -5,35 +5,3 @@
 .alert.alert-error > ul.error-list {
   margin-bottom: 0px;
 }
-
-
-/*
-** Timeish fixes.
-*/
-
-.datetime_select .form-control,
-.date_select .form-control,
-.time_select .form-control,
-.datetime .form-control,
-.date .form-control,
-.time .form-control
- {
-  border: none;
-  -webkit-box-shadow: none;
-  box-shadow: none;
-	padding: 0px 0px;
-}
-
-.datetime_select .form-control select,
-.date_select .form-control select,
-.time_select .form-control select,
-.datetime .form-control select,
-.date .form-control select,
-.time .form-control select 
-{
-	/* This works for me in FireFox but does not work in
-	   Safari or Chrome (31.)  If I set a background-color
-	   it will suddenly work in both of those browsers.
-	*/
-	height: 34px; 
-}


### PR DESCRIPTION
- puts all the :year, :month, and other columns into `div.row`.
- also fixes the grid column styling - date input fragments should fill in
  whole 12 grid units (see: `Timeish::FRAGMENT_CLASSES`,
  `DateSelectInput::FRAGMENT_CLASSES`, `TimeSelectInput::FRAGMENT_CLASSES`
