### PR TITLE
Add :inline option to Radio and CheckBoxesInput.

### DIFF
--- a/lib/formtastic-bootstrap/inputs/check_boxes_input.rb
+++ b/lib/formtastic-bootstrap/inputs/check_boxes_input.rb
@@ -5,7 +5,6 @@ module FormtasticBootstrap
       include Base::Choices
 
       # TODO Make sure help blocks work correctly.
-      # TODO Support .inline
 
       def to_html
         form_group_wrapping do
@@ -30,9 +29,11 @@ module FormtasticBootstrap
       end
 
       def checkbox_wrapping(&block)
+        class_name = "checkbox"
+        class_name += " checkbox-inline" if options[:inline]
         template.content_tag(:div,
           template.capture(&block).html_safe,
-          :class => "checkbox"
+          :class => class_name
         )
       end
 

--- a/lib/formtastic-bootstrap/inputs/radio_input.rb
+++ b/lib/formtastic-bootstrap/inputs/radio_input.rb
@@ -5,7 +5,6 @@ module FormtasticBootstrap
       include Base::Choices
 
       # TODO Make sure help blocks work correctly.
-      # TODO Support .inline
 
       def to_html
         form_group_wrapping do
@@ -35,9 +34,11 @@ module FormtasticBootstrap
       end
 
       def radio_wrapping(&block)
+        class_name = "radio"
+        class_name += " radio-inline" if options[:inline]
         template.content_tag(:div,
           template.capture(&block).html_safe,
-          :class => "radio"
+          :class => class_name
         )
       end
 


### PR DESCRIPTION
After passing `inline: true` option to `:radio` or `:check_boxes` input, input
container will be rendered with `.radio-inline` or `.checkbox-inline` class.
