### PR TITLE
Potential fix for issue #102

### DIFF
--- a/lib/formtastic-bootstrap/inputs/check_boxes_input.rb
+++ b/lib/formtastic-bootstrap/inputs/check_boxes_input.rb
@@ -7,12 +7,13 @@ module FormtasticBootstrap
       # TODO Make sure help blocks work correctly.
 
       def to_html
-        form_group_wrapping do
-          label_html <<
-          hidden_field_for_all << # Might need to remove this guy.
-          collection.map { |choice|
-            choice_html(choice)
-          }.join("\n").html_safe
+        bootstrap_wrapping do
+          form_group_wrapping do
+            hidden_field_for_all << # Might need to remove this guy.
+              collection.map { |choice|
+              choice_html(choice)
+            }.join("\n").html_safe
+          end
         end
       end
 


### PR DESCRIPTION
This fixes my issue with collection check_boxes not showing their error messages properly.

The solution here is to wrap the form_group with bootstrap_wrapping
which will set the label in the "right" place AND add the error
message in the right place.

It's not clear to me why this set of elements wasn't getting wrapped with the bootstrap_wrapping call.  If it was intentional - then this fix might have issues in other contexts.
