### PR TITLE
FormtasticBootstrap namespace for inputs breaks helper

### DIFF
--- a/lib/formtastic-bootstrap/helpers/input_helper.rb
+++ b/lib/formtastic-bootstrap/helpers/input_helper.rb
@@ -10,6 +10,8 @@ module FormtasticBootstrap
           input_class_name.constantize
         elsif FormtasticBootstrap::Inputs.const_defined?(input_class_name)
           standard_input_class_name(as).constantize
+        elsif Formtastic::Inputs.const_defined?(input_class_name)
+          standard_formtastic_class_name(as).constantize
         else
           raise Formtastic::UnknownInputError, "Unable to find input class #{input_class_name}"
         end
@@ -17,6 +19,10 @@ module FormtasticBootstrap
 
       def standard_input_class_name(as)
         "FormtasticBootstrap::Inputs::#{as.to_s.camelize}Input"
+      end
+
+      def standard_formtastic_class_name(as)
+        "Formtastic::Inputs::#{as.to_s.camelize}Input"
       end
 
     end

--- a/spec/helpers/input_helper_spec.rb
+++ b/spec/helpers/input_helper_spec.rb
@@ -930,16 +930,35 @@ describe 'FormtasticBootstrap::FormBuilder#input' do
     end
 
     describe 'when it searching for new input defined with namespace' do
-      subject { Class.new {extend FormtasticBootstrap::Helpers::InputHelper} }
+      context 'on production enviroment' do
+        subject { Class.new {extend FormtasticBootstrap::Helpers::InputHelper} }
 
-      before do
-        stub_const 'FormtasticBootstrap::Inputs::NewStringInput', double
-      end
+        let(:formtastic_input) { double(:formtastic_input) }
+        let(:formtastic_bootstrap_input) { double(:formtastic_bootstrap_input) }
 
-      it 'should use FormtasticBootstrap::Inputs as default scope' do
-        Rails.application.config.stub(:cache_classes).and_return(true)
-        expect(subject.input_class_with_const_defined(:new_string))
-          .to_not raise_error(Formtastic::UnknownInputError)
+        before(:each) do
+          Rails.application.config.stub(:cache_classes).and_return(true)
+        end
+
+        it 'should use FormtasticBootstrap::Inputs as default scope' do
+          stub_const 'FormtasticBootstrap::Inputs::NewStringInput', formtastic_bootstrap_input
+          expect(subject.input_class_with_const_defined(:new_string))
+            .to_not raise_error(Formtastic::UnknownInputError)
+        end
+
+        it 'should using Formtastic::Inputs namespace if there is no class in FormtasticBootstrap::Inputs' do
+          stub_const 'Formtastic::Inputs::NewStringInput', formtastic_input
+          expect(subject.input_class_with_const_defined(:new_string))
+            .to_not raise_error(Formtastic::UnknownInputError)
+        end
+
+        it 'should prefate FormtasticBootstrap namespace to Formtastic' do
+          stub_const 'FormtasticBootstrap::Inputs::NewStringInput',
+            formtastic_bootstrap_input
+          stub_const 'Formtastic::Inputs::NewStringInput', formtastic_input
+          subject.input_class_with_const_defined(:new_string).should
+            eql formtastic_bootstrap_input
+        end
       end
 
     end


### PR DESCRIPTION
In `lib/formtastic-bootstrap/helpers/input_helper.rb` you overwrite one method for default input constant name, but in parent method there is parent constant used with `const_defined?`. That constant should also be replaced.
