### PR TITLE
Support for non standard input classes

### DIFF
--- a/lib/formtastic-bootstrap/helpers/input_helper.rb
+++ b/lib/formtastic-bootstrap/helpers/input_helper.rb
@@ -16,6 +16,20 @@ module FormtasticBootstrap
           raise Formtastic::UnknownInputError, "Unable to find input class #{input_class_name}"
         end
       end
+      
+      def input_class_by_trying(as)
+        begin
+          custom_input_class_name(as).constantize
+        rescue NameError
+          begin
+            standard_input_class_name(as).constantize
+          rescue
+            standard_formtastic_class_name(as).constantize
+          end
+        end
+      rescue NameError
+        raise Formtastic::UnknownInputError, "Unable to find input class for #{as}"
+      end
 
       def standard_input_class_name(as)
         "FormtasticBootstrap::Inputs::#{as.to_s.camelize}Input"


### PR DESCRIPTION
Avoids the exception when using an input class not defined in FormtasticBootstrap namespace.
For example, I'm using activeadmin-select2 GEM and this error raises when using FormtasticBootstrap as form builder like this:

``` erb
<%= semantic_form_for [:admin, @invoice], builder: FormtasticBootstrap::FormBuilder do |f| %>
    <%= f.semantic_errors *f.object.errors.keys %>
    <%= f.inputs "Invoice" do %>
        <div class="row">
          <%= f.input :is_proforma, :wrapper_html => {:class => "col-md-1"} %>
          <%= f.input :partner, :as => :select2, :wrapper_html => {:class => "col-md-5"} %>
          <%= f.input :currency, :as => :select2, :wrapper_html => {:class => "col-md-2"} %>
          <%= f.input :currency_rate, :wrapper_html => {:class => "col-md-2"} %>
          <%= f.input :date_invoice, :as => :date_picker, :wrapper_html => {:class => "col-md-2"} %>
        </div>
    <% end %>
    <%= f.actions do %>
        <%= f.action :submit, :button_html => {:class => "btn btn-success pull-right"} %>
        <%= link_to "Cancel", [:admin, @invoice], {:class => "btn btn-default pull-right"} %>
    <% end %>
<% end %>
```
