### PR TITLE
Add bootstrap_wrapping to radio collection

### DIFF
--- a/lib/formtastic-bootstrap/inputs/radio_input.rb
+++ b/lib/formtastic-bootstrap/inputs/radio_input.rb
@@ -7,8 +7,7 @@ module FormtasticBootstrap
       # TODO Make sure help blocks work correctly.
 
       def to_html
-        form_group_wrapping do
-          label_html <<
+        bootstrap_wrapping do
           collection.map { |choice|
             choice_html(choice)
           }.join("\n").html_safe


### PR DESCRIPTION
As is in checkbox collection. This essentially adds the missing "form-wrapper" span tag to allow for better formatting of the radio buttons!
