### PR TITLE
Formtastic 3.1 select improvements

### DIFF
--- a/lib/formtastic-bootstrap/inputs/select_input.rb
+++ b/lib/formtastic-bootstrap/inputs/select_input.rb
@@ -5,26 +5,9 @@ module FormtasticBootstrap
       include Base
       include Base::Collections
 
-      def select_html
-        builder.select(input_name, collection, input_options, form_control_input_html_options)
-      end
-
-      def grouped_select_html
-        builder.grouped_collection_select(
-          input_name,
-          grouped_collection,
-          group_association,
-          group_label_method,
-          value_method,
-          label_method,
-          input_options,
-          form_control_input_html_options
-        )
-      end
-      
       def to_html
         bootstrap_wrapping do
-          options[:group_by] ? grouped_select_html : select_html
+          builder.select(input_name, collection, input_options, form_control_input_html_options)
         end
       end
 

--- a/spec/builder/action_spec.rb
+++ b/spec/builder/action_spec.rb
@@ -99,7 +99,7 @@ describe 'FormtasticBootstrap::FormBuilder#action' do
     #          it 'should render a label with localized text and not apply the label_str_method' do
     #            with_config :label_str_method, :reverse do
     #              @localized_label_text = 'Localized title'
-    #              @new_post.stub!(:meta_description)
+    #              @new_post.stub(:meta_description)
     #              ::I18n.backend.store_translations :en,
     #                :formtastic => {
     #                  :labels => {
@@ -132,7 +132,7 @@ describe 'FormtasticBootstrap::FormBuilder#action' do
     #
     #      describe 'and object is given' do
     #        it 'should delegate the label logic to class human attribute name and pass it down to the label tag' do
-    #          @new_post.stub!(:meta_description) # a two word method name
+    #          @new_post.stub(:meta_description) # a two word method name
     #          @new_post.class.should_receive(:human_attribute_name).with('meta_description').and_return('meta_description'.humanize)
     #
     #          concat(semantic_form_for(@new_post) do |builder|
@@ -145,7 +145,7 @@ describe 'FormtasticBootstrap::FormBuilder#action' do
     #      describe 'and object is given with label_str_method set to :capitalize' do
     #        it 'should capitalize method name, passing it down to the label tag' do
     #          with_config :label_str_method, :capitalize do
-    #            @new_post.stub!(:meta_description)
+    #            @new_post.stub(:meta_description)
     #
     #            concat(semantic_form_for(@new_post) do |builder|
     #              concat(builder.input(:meta_description))

--- a/spec/builder/semantic_fields_for_spec.rb
+++ b/spec/builder/semantic_fields_for_spec.rb
@@ -7,7 +7,7 @@ describe 'FormtasticBootstrap::FormBuilder#fields_for' do
   before do
     @output_buffer = ''
     mock_everything
-    @new_post.stub!(:author).and_return(::Author.new)
+    @new_post.stub(:author).and_return(::Author.new)
 
     Formtastic::Helpers::FormHelper.builder = FormtasticBootstrap::FormBuilder
   end
@@ -78,7 +78,7 @@ describe 'FormtasticBootstrap::FormBuilder#fields_for' do
     end
 
     it 'should sanitize html id for li tag' do
-      @bob.stub!(:column_for_attribute).and_return(mock('column', :type => :string, :limit => 255))
+      @bob.stub(:column_for_attribute).and_return(double('column', :type => :string, :limit => 255))
       concat(semantic_form_for(@new_post) do |builder|
         concat(builder.semantic_fields_for(@bob, :index => 1) do |nested_builder|
           concat(nested_builder.inputs(:login))
@@ -91,7 +91,7 @@ describe 'FormtasticBootstrap::FormBuilder#fields_for' do
     end
 
     it 'should use namespace provided in nested fields' do
-      @bob.stub!(:column_for_attribute).and_return(mock('column', :type => :string, :limit => 255))
+      @bob.stub(:column_for_attribute).and_return(double('column', :type => :string, :limit => 255))
       concat(semantic_form_for(@new_post, :namespace => 'context2') do |builder|
         concat(builder.semantic_fields_for(@bob, :index => 1) do |nested_builder|
           concat(nested_builder.inputs(:login))
@@ -107,8 +107,8 @@ describe 'FormtasticBootstrap::FormBuilder#fields_for' do
       output_buffer.replace ''
 
       @fred.posts.size.should == 1
-      @fred.posts.first.stub!(:persisted?).and_return(true)
-      @fred.stub!(:posts_attributes=)
+      @fred.posts.first.stub(:persisted?).and_return(true)
+      @fred.stub(:posts_attributes=)
 
       concat(semantic_form_for(@fred) do |builder|
         concat(builder.semantic_fields_for(:posts) do |nested_builder|

--- a/spec/helpers/inputs_helper_spec.rb
+++ b/spec/helpers/inputs_helper_spec.rb
@@ -56,12 +56,12 @@ describe 'FormtasticBootstrap::FormBuilder#inputs' do
     describe 'when a :for option is provided' do
 
       before do
-        @new_post.stub!(:respond_to?).and_return(true, true)
-        @new_post.stub!(:author).and_return(@bob)
+        @new_post.stub(:respond_to?).and_return(true, true)
+        @new_post.stub(:author).and_return(@bob)
       end
 
       it 'should render nested inputs' do
-        @bob.stub!(:column_for_attribute).and_return(mock('column', :type => :string, :limit => 255))
+        @bob.stub(:column_for_attribute).and_return(double('column', :type => :string, :limit => 255))
 
         concat(semantic_form_for(@new_post) do |builder|
           inputs = builder.inputs :for => [:author, @bob] do |bob_builder|
@@ -74,7 +74,7 @@ describe 'FormtasticBootstrap::FormBuilder#inputs' do
       end
 
       it 'should concat rendered nested inputs to the template' do
-        @bob.stub!(:column_for_attribute).and_return(mock('column', :type => :string, :limit => 255))
+        @bob.stub(:column_for_attribute).and_return(double('column', :type => :string, :limit => 255))
 
         concat(semantic_form_for(@new_post) do |builder|
           builder.inputs :for => [:author, @bob] do |bob_builder|
@@ -103,8 +103,8 @@ describe 'FormtasticBootstrap::FormBuilder#inputs' do
 
       describe "as a symbol representing a has_many association name" do
         before do
-          @new_post.stub!(:authors).and_return([@bob, @fred])
-          @new_post.stub!(:authors_attributes=)
+          @new_post.stub(:authors).and_return([@bob, @fred])
+          @new_post.stub(:authors_attributes=)
         end
 
         it 'should nest the inputs with a fieldset, legend and :name input for each item' do
@@ -176,7 +176,7 @@ describe 'FormtasticBootstrap::FormBuilder#inputs' do
       end
 
       it 'should pass options down to semantic_fields_for' do
-        @bob.stub!(:column_for_attribute).and_return(mock('column', :type => :string, :limit => 255))
+        @bob.stub(:column_for_attribute).and_return(double('column', :type => :string, :limit => 255))
 
         concat(semantic_form_for(@new_post) do |builder|
           inputs = builder.inputs :for => [:author, @bob], :for_options => { :index => 10 } do |bob_builder|
@@ -342,18 +342,18 @@ describe 'FormtasticBootstrap::FormBuilder#inputs' do
   describe 'without a block' do
 
     before do
-      ::Post.stub!(:reflections).and_return({:author => mock('reflection', :options => {}, :macro => :belongs_to),
-                                           :comments => mock('reflection', :options => {}, :macro => :has_many) })
-      ::Author.stub!(:find).and_return([@fred, @bob])
+      ::Post.stub(:reflections).and_return({:author => double('reflection', :options => {}, :macro => :belongs_to),
+                                           :comments => double('reflection', :options => {}, :macro => :has_many) })
+      ::Author.stub(:find).and_return([@fred, @bob])
 
-      @new_post.stub!(:title)
-      @new_post.stub!(:body)
-      @new_post.stub!(:author_id)
+      @new_post.stub(:title)
+      @new_post.stub(:body)
+      @new_post.stub(:author_id)
 
-      @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :string, :limit => 255))
-      @new_post.stub!(:column_for_attribute).with(:body).and_return(mock('column', :type => :text))
-      @new_post.stub!(:column_for_attribute).with(:created_at).and_return(mock('column', :type => :datetime))
-      @new_post.stub!(:column_for_attribute).with(:author).and_return(nil)
+      @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :string, :limit => 255))
+      @new_post.stub(:column_for_attribute).with(:body).and_return(double('column', :type => :text))
+      @new_post.stub(:column_for_attribute).with(:created_at).and_return(double('column', :type => :datetime))
+      @new_post.stub(:column_for_attribute).with(:author).and_return(nil)
     end
 
     describe 'with no args (quick forms syntax)' do
@@ -404,12 +404,12 @@ describe 'FormtasticBootstrap::FormBuilder#inputs' do
       context "with a polymorphic association" do
 
         before do
-          @new_post.stub!(:commentable)
-          @new_post.class.stub!(:reflections).and_return({
-            :commentable => mock('macro_reflection', :options => { :polymorphic => true }, :macro => :belongs_to)
+          @new_post.stub(:commentable)
+          @new_post.class.stub(:reflections).and_return({
+            :commentable => double('macro_reflection', :options => { :polymorphic => true }, :macro => :belongs_to)
           })
-          @new_post.stub!(:column_for_attribute).with(:commentable).and_return(
-            mock('column', :type => :integer)
+          @new_post.stub(:column_for_attribute).with(:commentable).and_return(
+            double('column', :type => :integer)
           )
         end
 
@@ -454,15 +454,15 @@ describe 'FormtasticBootstrap::FormBuilder#inputs' do
       context "with a polymorphic association" do
 
         it 'should raise an error for polymorphic associations (the collection class cannot be guessed)' do
-          @new_post.stub!(:commentable)
-          @new_post.class.stub!(:reflections).and_return({
-            :commentable => mock('macro_reflection', :options => { :polymorphic => true }, :macro => :belongs_to)
+          @new_post.stub(:commentable)
+          @new_post.class.stub(:reflections).and_return({
+            :commentable => double('macro_reflection', :options => { :polymorphic => true }, :macro => :belongs_to)
           })
-          @new_post.stub!(:column_for_attribute).with(:commentable).and_return(
-            mock('column', :type => :integer)
+          @new_post.stub(:column_for_attribute).with(:commentable).and_return(
+            double('column', :type => :integer)
           )
-          @new_post.class.stub!(:reflect_on_association).with(:commentable).and_return(
-            mock('reflection', :macro => :belongs_to, :options => { :polymorphic => true })
+          @new_post.class.stub(:reflect_on_association).with(:commentable).and_return(
+            double('reflection', :macro => :belongs_to, :options => { :polymorphic => true })
           )
 
           expect {
@@ -479,7 +479,7 @@ describe 'FormtasticBootstrap::FormBuilder#inputs' do
     describe 'when a :for option is provided' do
       describe 'and an object is given' do
         it 'should render nested inputs' do
-          @bob.stub!(:column_for_attribute).and_return(mock('column', :type => :string, :limit => 255))
+          @bob.stub(:column_for_attribute).and_return(double('column', :type => :string, :limit => 255))
           concat(semantic_form_for(@new_post) do |builder|
             concat(builder.inputs(:login, :for => @bob))
           end)

--- a/spec/helpers/semantic_errors_helper_spec.rb
+++ b/spec/helpers/semantic_errors_helper_spec.rb
@@ -11,13 +11,13 @@ describe 'FormtasticBootstrap::FormBuilder#semantic_errors' do
     @title_errors = ['must not be blank', 'must be awesome']
     @base_errors = ['base error message', 'nasty error']
     @base_error = 'one base error'
-    @errors = mock('errors')
-    @new_post.stub!(:errors).and_return(@errors)
+    @errors = double('errors')
+    @new_post.stub(:errors).and_return(@errors)
   end
 
   describe 'when there is only one error on base' do
     before do
-      @errors.stub!(:[]).with(errors_matcher(:base)).and_return(@base_error)
+      @errors.stub(:[]).with(errors_matcher(:base)).and_return(@base_error)
     end
 
     it 'should render an alert with an unordered list' do
@@ -29,7 +29,7 @@ describe 'FormtasticBootstrap::FormBuilder#semantic_errors' do
 
   describe 'when there is more than one error on base' do
     before do
-      @errors.stub!(:[]).with(errors_matcher(:base)).and_return(@base_errors)
+      @errors.stub(:[]).with(errors_matcher(:base)).and_return(@base_errors)
     end
 
     it 'should render an unordered list' do
@@ -44,8 +44,8 @@ describe 'FormtasticBootstrap::FormBuilder#semantic_errors' do
 
   describe 'when there are errors on title' do
     before do
-      @errors.stub!(:[]).with(errors_matcher(:title)).and_return(@title_errors)
-      @errors.stub!(:[]).with(errors_matcher(:base)).and_return([])
+      @errors.stub(:[]).with(errors_matcher(:title)).and_return(@title_errors)
+      @errors.stub(:[]).with(errors_matcher(:base)).and_return([])
     end
 
     it 'should render an unordered list' do
@@ -58,8 +58,8 @@ describe 'FormtasticBootstrap::FormBuilder#semantic_errors' do
 
   describe 'when there are errors on title and base' do
     before do
-      @errors.stub!(:[]).with(errors_matcher(:title)).and_return(@title_errors)
-      @errors.stub!(:[]).with(errors_matcher(:base)).and_return(@base_error)
+      @errors.stub(:[]).with(errors_matcher(:title)).and_return(@title_errors)
+      @errors.stub(:[]).with(errors_matcher(:base)).and_return(@base_error)
     end
 
     it 'should render an unordered list' do
@@ -73,8 +73,8 @@ describe 'FormtasticBootstrap::FormBuilder#semantic_errors' do
 
   describe 'when there are no errors' do
     before do
-      @errors.stub!(:[]).with(errors_matcher(:title)).and_return(nil)
-      @errors.stub!(:[]).with(errors_matcher(:base)).and_return(nil)
+      @errors.stub(:[]).with(errors_matcher(:title)).and_return(nil)
+      @errors.stub(:[]).with(errors_matcher(:base)).and_return(nil)
     end
 
     it 'should return nil' do
@@ -86,7 +86,7 @@ describe 'FormtasticBootstrap::FormBuilder#semantic_errors' do
 
   describe 'when there is one error on base and options with class is passed' do
     before do
-      @errors.stub!(:[]).with(errors_matcher(:base)).and_return(@base_error)
+      @errors.stub(:[]).with(errors_matcher(:base)).and_return(@base_error)
     end
 
     it 'should render an unordered list with given class' do
@@ -98,7 +98,7 @@ describe 'FormtasticBootstrap::FormBuilder#semantic_errors' do
 
   describe 'when :base is passed in as an argument' do
     before do
-      @errors.stub!(:[]).with(errors_matcher(:base)).and_return(@base_error)
+      @errors.stub(:[]).with(errors_matcher(:base)).and_return(@base_error)
     end
 
     it 'should ignore :base and only render base errors once' do

--- a/spec/inputs/boolean_input_spec.rb
+++ b/spec/inputs/boolean_input_spec.rb
@@ -101,7 +101,7 @@ describe 'boolean input' do
   end
 
   it 'should generate a checked input if object.method returns checked value' do
-    @new_post.stub!(:allow_comments).and_return('yes')
+    @new_post.stub(:allow_comments).and_return('yes')
 
     concat(semantic_form_for(@new_post) do |builder|
       concat(builder.input(:allow_comments, :as => :boolean, :checked_value => 'yes', :unchecked_value => 'no'))
@@ -111,7 +111,7 @@ describe 'boolean input' do
   end
 
   it 'should not generate a checked input if object.method returns unchecked value' do
-    @new_post.stub!(:allow_comments).and_return('no')
+    @new_post.stub(:allow_comments).and_return('no')
 
     concat(semantic_form_for(@new_post) do |builder|
       concat(builder.input(:allow_comments, :as => :boolean, :checked_value => 'yes', :unchecked_value => 'no'))
@@ -121,7 +121,7 @@ describe 'boolean input' do
   end
 
   it 'should generate a checked input if object.method returns checked value' do
-    @new_post.stub!(:allow_comments).and_return('yes')
+    @new_post.stub(:allow_comments).and_return('yes')
 
     concat(semantic_form_for(@new_post) do |builder|
       concat(builder.input(:allow_comments, :as => :boolean, :checked_value => 'yes', :unchecked_value => 'no'))
@@ -131,7 +131,7 @@ describe 'boolean input' do
   end
 
   it 'should not generate a checked input if object.method returns unchecked value' do
-    @new_post.stub!(:allow_comments).and_return('no')
+    @new_post.stub(:allow_comments).and_return('no')
 
     concat(semantic_form_for(@new_post) do |builder|
       concat(builder.input(:allow_comments, :as => :boolean, :checked_value => 'yes', :unchecked_value => 'no'))

--- a/spec/inputs/check_boxes_input_spec.rb
+++ b/spec/inputs/check_boxes_input_spec.rb
@@ -200,7 +200,7 @@ describe 'check_boxes input' do
 
       describe "no disabled items" do
         before do
-          @new_post.stub!(:author_ids).and_return(nil)
+          @new_post.stub(:author_ids).and_return(nil)
 
           concat(semantic_form_for(@new_post) do |builder|
             concat(builder.input(:authors, :as => :check_boxes, :disabled => nil))
@@ -214,7 +214,7 @@ describe 'check_boxes input' do
 
       describe "single disabled item" do
         before do
-          @new_post.stub!(:author_ids).and_return(nil)
+          @new_post.stub(:author_ids).and_return(nil)
 
           concat(semantic_form_for(@new_post) do |builder|
             concat(builder.input(:authors, :as => :check_boxes, :disabled => @fred.id))
@@ -230,7 +230,7 @@ describe 'check_boxes input' do
 
       describe "multiple disabled items" do
         before do
-          @new_post.stub!(:author_ids).and_return(nil)
+          @new_post.stub(:author_ids).and_return(nil)
 
           concat(semantic_form_for(@new_post) do |builder|
             concat(builder.input(:authors, :as => :check_boxes, :disabled => [@bob.id, @fred.id]))
@@ -253,7 +253,7 @@ describe 'check_boxes input' do
       before do
         ::I18n.backend.store_translations :en, :formtastic => { :labels => { :post => { :authors => "Translated!" }}}
         with_config :i18n_lookups_by_default, true do
-          @new_post.stub!(:author_ids).and_return(nil)
+          @new_post.stub(:author_ids).and_return(nil)
           concat(semantic_form_for(@new_post) do |builder|
             concat(builder.input(:authors, :as => :check_boxes))
           end)
@@ -272,7 +272,7 @@ describe 'check_boxes input' do
 
     describe "when :label option is set" do
       before do
-        @new_post.stub!(:author_ids).and_return(nil)
+        @new_post.stub(:author_ids).and_return(nil)
         concat(semantic_form_for(@new_post) do |builder|
           concat(builder.input(:authors, :as => :check_boxes, :label => 'The authors'))
         end)
@@ -286,7 +286,7 @@ describe 'check_boxes input' do
     describe "when :label option is false" do
       before do
         @output_buffer = ''
-        @new_post.stub!(:author_ids).and_return(nil)
+        @new_post.stub(:author_ids).and_return(nil)
         concat(semantic_form_for(@new_post) do |builder|
           concat(builder.input(:authors, :as => :check_boxes, :label => false))
         end)
@@ -304,7 +304,7 @@ describe 'check_boxes input' do
 
     describe "when :required option is true" do
       before do
-        @new_post.stub!(:author_ids).and_return(nil)
+        @new_post.stub(:author_ids).and_return(nil)
         concat(semantic_form_for(@new_post) do |builder|
           concat(builder.input(:authors, :as => :check_boxes, :required => true))
         end)
@@ -350,9 +350,9 @@ describe 'check_boxes input' do
       end
 
       it 'to set the right input value' do
-        item = mock('item')
+        item = double('item')
         item.should_not_receive(:id)
-        item.stub!(:custom_value).and_return('custom_value')
+        item.stub(:custom_value).and_return('custom_value')
         item.should_receive(:custom_value).exactly(3).times
         @new_post.author.should_receive(:custom_value).exactly(1).times
         concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/color_input_spec.rb
+++ b/spec/inputs/color_input_spec.rb
@@ -46,11 +46,11 @@ describe 'color input' do
       let(:default_maxlength) { 50 }
 
       before do
-        @new_post.stub!(:class).and_return(::PostModel)
+        @new_post.stub(:class).and_return(::PostModel)
       end
 
       after do
-        @new_post.stub!(:class).and_return(::Post)
+        @new_post.stub(:class).and_return(::Post)
       end
 
       describe 'and validates_length_of was called for the method' do

--- a/spec/inputs/date_picker_input_spec.rb
+++ b/spec/inputs/date_picker_input_spec.rb
@@ -123,7 +123,7 @@ describe 'date_picker input' do
 
       before do
         @date = Date.new(2000, 11, 11)
-        @new_post.stub!(:publish_at).and_return(@date)
+        @new_post.stub(:publish_at).and_return(@date)
       end
 
       it "renders the date as YYYY-MM-DD" do
@@ -150,7 +150,7 @@ describe 'date_picker input' do
 
       before do
         @time = Time.utc(2000,11,11,11,11,11)
-        @new_post.stub!(:publish_at).and_return(@time)
+        @new_post.stub(:publish_at).and_return(@time)
       end
 
       it "renders the time as a YYYY-MM-DD" do
@@ -176,7 +176,7 @@ describe 'date_picker input' do
     context "when method returns an empty String" do
 
       before do
-        @new_post.stub!(:publish_at).and_return("")
+        @new_post.stub(:publish_at).and_return("")
       end
 
       it "will be empty" do
@@ -202,7 +202,7 @@ describe 'date_picker input' do
     context "when method returns a String" do
 
       before do
-        @new_post.stub!(:publish_at).and_return("yeah")
+        @new_post.stub(:publish_at).and_return("yeah")
       end
 
       it "will be the string" do

--- a/spec/inputs/date_select_input_spec.rb
+++ b/spec/inputs/date_select_input_spec.rb
@@ -95,7 +95,7 @@ describe 'date select input' do
 
   describe ':labels option' do
     it "should provide a message that :labels is not supported" do
-      pending ':labels is not supported'
+      skip ':labels is not supported'
     end
   end
 

--- a/spec/inputs/datetime_picker_input_spec.rb
+++ b/spec/inputs/datetime_picker_input_spec.rb
@@ -158,7 +158,7 @@ describe 'datetime_picker input' do
 
       before do
         @date = Date.new(2000, 11, 11)
-        @new_post.stub!(:publish_at).and_return(@date)
+        @new_post.stub(:publish_at).and_return(@date)
       end
 
       it "renders the date as YYYY-MM-DD 00:00" do
@@ -185,7 +185,7 @@ describe 'datetime_picker input' do
 
       before do
         @time = Time.utc(2000,11,11,11,11,11)
-        @new_post.stub!(:publish_at).and_return(@time)
+        @new_post.stub(:publish_at).and_return(@time)
       end
 
       it "renders the time as a YYYY-MM-DD HH:MM" do
@@ -211,7 +211,7 @@ describe 'datetime_picker input' do
     context "when method returns an empty String" do
 
       before do
-        @new_post.stub!(:publish_at).and_return("")
+        @new_post.stub(:publish_at).and_return("")
       end
 
       it "will be empty" do
@@ -237,7 +237,7 @@ describe 'datetime_picker input' do
     context "when method returns a String" do
 
       before do
-        @new_post.stub!(:publish_at).and_return("yeah")
+        @new_post.stub(:publish_at).and_return("yeah")
       end
 
       it "will be the string" do

--- a/spec/inputs/datetime_select_input_spec.rb
+++ b/spec/inputs/datetime_select_input_spec.rb
@@ -92,7 +92,7 @@ describe 'datetime select input' do
   describe ':labels option' do
     describe ':labels option' do
       it "should provide a message that :labels is not supported" do
-        pending ':labels is not supported'
+        skip ':labels is not supported'
       end
     end
 

--- a/spec/inputs/hidden_input_spec.rb
+++ b/spec/inputs/hidden_input_spec.rb
@@ -54,9 +54,9 @@ describe 'hidden input' do
   end
 
   it "should not render inline errors" do
-    @errors = mock('errors')
-    @errors.stub!(:[]).with(errors_matcher(:secret)).and_return(["foo", "bah"])
-    @new_post.stub!(:errors).and_return(@errors)
+    @errors = double('errors')
+    @errors.stub(:[]).with(errors_matcher(:secret)).and_return(["foo", "bah"])
+    @new_post.stub(:errors).and_return(@errors)
 
     concat(semantic_form_for(@new_post) do |builder|
       concat(builder.input(:secret, :as => :hidden))

--- a/spec/inputs/number_input_spec.rb
+++ b/spec/inputs/number_input_spec.rb
@@ -9,7 +9,7 @@ describe 'number input' do
     @output_buffer = ''
     mock_everything
 
-    @new_post.class.stub!(:validators_on).with(:title).and_return([
+    @new_post.class.stub(:validators_on).with(:title).and_return([
       active_model_numericality_validator([:title], {:only_integer=>false, :allow_nil=>false, :greater_than=>2})
     ])
   end
@@ -110,7 +110,7 @@ describe 'number input' do
 
   describe "when validations require a minimum value (:greater_than)" do
     before do
-      @new_post.class.stub!(:validators_on).with(:title).and_return([
+      @new_post.class.stub(:validators_on).with(:title).and_return([
         active_model_numericality_validator([:title], {:only_integer=>false, :allow_nil=>false, :greater_than=>2})
       ])
     end
@@ -145,7 +145,7 @@ describe 'number input' do
 
     describe "and the column is an integer" do
       before do
-        @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :integer))
+        @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :integer))
       end
 
       it "should add a min attribute to the input one greater than the validation" do
@@ -158,7 +158,7 @@ describe 'number input' do
 
     describe "and the column is a float" do
       before do
-        @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :float))
+        @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :float))
       end
 
       it "should raise an error" do
@@ -172,7 +172,7 @@ describe 'number input' do
 
     describe "and the column is a big decimal" do
       before do
-        @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :decimal))
+        @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :decimal))
       end
 
       it "should raise an error" do
@@ -188,7 +188,7 @@ describe 'number input' do
 
   describe "when validations require a minimum value (:greater_than) that takes a proc" do
     before do
-      @new_post.class.stub!(:validators_on).with(:title).and_return([
+      @new_post.class.stub(:validators_on).with(:title).and_return([
         active_model_numericality_validator([:title], {:only_integer=>false, :allow_nil=>false, :greater_than=> Proc.new {|post| 2}})
       ])
     end
@@ -223,7 +223,7 @@ describe 'number input' do
 
     describe "and the column is an integer" do
       before do
-        @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :integer))
+        @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :integer))
       end
 
       it "should add a min attribute to the input one greater than the validation" do
@@ -236,7 +236,7 @@ describe 'number input' do
 
     describe "and the column is a float" do
       before do
-        @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :float))
+        @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :float))
       end
 
       it "should raise an error" do
@@ -250,7 +250,7 @@ describe 'number input' do
 
     describe "and the column is a big decimal" do
       before do
-        @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :decimal))
+        @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :decimal))
       end
 
       it "should raise an error" do
@@ -266,7 +266,7 @@ describe 'number input' do
 
   describe "when validations require a minimum value (:greater_than_or_equal_to)" do
     before do
-      @new_post.class.stub!(:validators_on).with(:title).and_return([
+      @new_post.class.stub(:validators_on).with(:title).and_return([
         active_model_numericality_validator([:title], {:only_integer=>false, :allow_nil=>false, :greater_than_or_equal_to=>2})
       ])
     end
@@ -303,7 +303,7 @@ describe 'number input' do
     [:integer, :decimal, :float].each do |column_type|
       describe "and the column is a #{column_type}" do
         before do
-          @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => column_type))
+          @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => column_type))
         end
 
         it "should add a max attribute to the input equal to the validation" do
@@ -317,7 +317,7 @@ describe 'number input' do
 
     describe "and there is no column" do
       before do
-        @new_post.stub!(:column_for_attribute).with(:title).and_return(nil)
+        @new_post.stub(:column_for_attribute).with(:title).and_return(nil)
       end
 
       it "should add a max attribute to the input equal to the validation" do
@@ -331,7 +331,7 @@ describe 'number input' do
 
   describe "when validations require a minimum value (:greater_than_or_equal_to) that takes a Proc" do
      before do
-       @new_post.class.stub!(:validators_on).with(:title).and_return([
+       @new_post.class.stub(:validators_on).with(:title).and_return([
          active_model_numericality_validator([:title], {:only_integer=>false, :allow_nil=>false, :greater_than_or_equal_to=> Proc.new { |post| 2}})
        ])
      end
@@ -368,7 +368,7 @@ describe 'number input' do
      [:integer, :decimal, :float].each do |column_type|
        describe "and the column is a #{column_type}" do
          before do
-           @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => column_type))
+           @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => column_type))
          end
 
          it "should add a max attribute to the input equal to the validation" do
@@ -382,7 +382,7 @@ describe 'number input' do
 
      describe "and there is no column" do
        before do
-         @new_post.stub!(:column_for_attribute).with(:title).and_return(nil)
+         @new_post.stub(:column_for_attribute).with(:title).and_return(nil)
        end
 
        it "should add a max attribute to the input equal to the validation" do
@@ -397,7 +397,7 @@ describe 'number input' do
   describe "when validations require a maximum value (:less_than)" do
 
    before do
-     @new_post.class.stub!(:validators_on).with(:title).and_return([
+     @new_post.class.stub(:validators_on).with(:title).and_return([
        active_model_numericality_validator([:title], {:only_integer=>false, :allow_nil=>false, :less_than=>20})
      ])
    end
@@ -432,7 +432,7 @@ describe 'number input' do
 
    describe "and the column is an integer" do
      before do
-       @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :integer))
+       @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :integer))
      end
 
      it "should add a max attribute to the input one greater than the validation" do
@@ -445,7 +445,7 @@ describe 'number input' do
 
    describe "and the column is a float" do
      before do
-       @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :float))
+       @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :float))
      end
 
      it "should raise an error" do
@@ -459,7 +459,7 @@ describe 'number input' do
 
    describe "and the column is a big decimal" do
      before do
-       @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :decimal))
+       @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :decimal))
      end
 
      it "should raise an error" do
@@ -472,7 +472,7 @@ describe 'number input' do
    end
    describe "and the validator takes a proc" do
      before do
-       @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :decimal))
+       @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :decimal))
      end
    end
   end
@@ -480,7 +480,7 @@ describe 'number input' do
   describe "when validations require a maximum value (:less_than) that takes a Proc" do
 
    before do
-     @new_post.class.stub!(:validators_on).with(:title).and_return([
+     @new_post.class.stub(:validators_on).with(:title).and_return([
        active_model_numericality_validator([:title], {:only_integer=>false, :allow_nil=>false, :less_than=> Proc.new {|post| 20 }})
      ])
    end
@@ -515,7 +515,7 @@ describe 'number input' do
 
    describe "and the column is an integer" do
      before do
-       @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :integer))
+       @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :integer))
      end
 
      it "should add a max attribute to the input one greater than the validation" do
@@ -528,7 +528,7 @@ describe 'number input' do
 
    describe "and the column is a float" do
      before do
-       @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :float))
+       @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :float))
      end
 
      it "should raise an error" do
@@ -542,7 +542,7 @@ describe 'number input' do
 
    describe "and the column is a big decimal" do
      before do
-       @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :decimal))
+       @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :decimal))
      end
 
      it "should raise an error" do
@@ -555,7 +555,7 @@ describe 'number input' do
    end
    describe "and the validator takes a proc" do
      before do
-       @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :decimal))
+       @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :decimal))
      end
    end
   end
@@ -563,7 +563,7 @@ describe 'number input' do
 
   describe "when validations require a maximum value (:less_than_or_equal_to)" do
     before do
-      @new_post.class.stub!(:validators_on).with(:title).and_return([
+      @new_post.class.stub(:validators_on).with(:title).and_return([
         active_model_numericality_validator([:title], {:only_integer=>false, :allow_nil=>false, :less_than_or_equal_to=>20})
       ])
     end
@@ -599,7 +599,7 @@ describe 'number input' do
     [:integer, :decimal, :float].each do |column_type|
       describe "and the column is a #{column_type}" do
         before do
-          @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => column_type))
+          @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => column_type))
         end
 
         it "should add a max attribute to the input equal to the validation" do
@@ -613,7 +613,7 @@ describe 'number input' do
 
     describe "and there is no column" do
       before do
-        @new_post.stub!(:column_for_attribute).with(:title).and_return(nil)
+        @new_post.stub(:column_for_attribute).with(:title).and_return(nil)
       end
 
       it "should add a max attribute to the input equal to the validation" do
@@ -627,7 +627,7 @@ describe 'number input' do
 
   describe "when validations require a maximum value (:less_than_or_equal_to) that takes a proc" do
      before do
-       @new_post.class.stub!(:validators_on).with(:title).and_return([
+       @new_post.class.stub(:validators_on).with(:title).and_return([
          active_model_numericality_validator([:title], {:only_integer=>false, :allow_nil=>false, :less_than_or_equal_to=> Proc.new { |post| 20 }})
        ])
      end
@@ -663,7 +663,7 @@ describe 'number input' do
      [:integer, :decimal, :float].each do |column_type|
        describe "and the column is a #{column_type}" do
          before do
-           @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => column_type))
+           @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => column_type))
          end
 
          it "should add a max attribute to the input equal to the validation" do
@@ -677,7 +677,7 @@ describe 'number input' do
 
      describe "and there is no column" do
        before do
-         @new_post.stub!(:column_for_attribute).with(:title).and_return(nil)
+         @new_post.stub(:column_for_attribute).with(:title).and_return(nil)
        end
 
        it "should add a max attribute to the input equal to the validation" do
@@ -691,7 +691,7 @@ describe 'number input' do
 
   describe "when validations require conflicting minimum values (:greater_than, :greater_than_or_equal_to)" do
     before do
-      @new_post.class.stub!(:validators_on).with(:title).and_return([
+      @new_post.class.stub(:validators_on).with(:title).and_return([
         active_model_numericality_validator([:title], {:only_integer=>false, :allow_nil=>false, :greater_than => 20, :greater_than_or_equal_to=>2})
       ])
     end
@@ -706,7 +706,7 @@ describe 'number input' do
 
   describe "when validations require conflicting maximum values (:less_than, :less_than_or_equal_to)" do
     before do
-      @new_post.class.stub!(:validators_on).with(:title).and_return([
+      @new_post.class.stub(:validators_on).with(:title).and_return([
         active_model_numericality_validator([:title], {:only_integer=>false, :allow_nil=>false, :less_than => 20, :less_than_or_equal_to=>2})
       ])
     end
@@ -722,7 +722,7 @@ describe 'number input' do
   describe "when validations require only an integer (:only_integer)" do
 
     before do
-      @new_post.class.stub!(:validators_on).with(:title).and_return([
+      @new_post.class.stub(:validators_on).with(:title).and_return([
         active_model_numericality_validator([:title], {:allow_nil=>false, :only_integer=>true})
       ])
     end
@@ -753,7 +753,7 @@ describe 'number input' do
   describe "when validations require a :step (non standard)" do
 
     before do
-      @new_post.class.stub!(:validators_on).with(:title).and_return([
+      @new_post.class.stub(:validators_on).with(:title).and_return([
         active_model_numericality_validator([:title], {:allow_nil=>false, :only_integer=>true, :step=>2})
       ])
     end
@@ -784,7 +784,7 @@ describe 'number input' do
   describe "when validations do not specify :step (non standard) or :only_integer" do
 
     before do
-      @new_post.class.stub!(:validators_on).with(:title).and_return([
+      @new_post.class.stub(:validators_on).with(:title).and_return([
         active_model_numericality_validator([:title], {:allow_nil=>false})
       ])
     end

--- a/spec/inputs/radio_input_spec.rb
+++ b/spec/inputs/radio_input_spec.rb
@@ -142,7 +142,7 @@ describe 'radio input' do
       ::I18n.backend.store_translations :en, :formtastic => { :labels => { :post => { :authors => "Translated!" }}}
 
       with_config :i18n_lookups_by_default, true do
-        @new_post.stub!(:author_ids).and_return(nil)
+        @new_post.stub(:author_ids).and_return(nil)
         concat(semantic_form_for(@new_post) do |builder|
           concat(builder.input(:authors, :as => :radio))
         end)
@@ -161,7 +161,7 @@ describe 'radio input' do
 
   describe "when :label option is set" do
     before do
-      @new_post.stub!(:author_ids).and_return(nil)
+      @new_post.stub(:author_ids).and_return(nil)
       concat(semantic_form_for(@new_post) do |builder|
         concat(builder.input(:authors, :as => :radio, :label => 'The authors'))
       end)
@@ -175,7 +175,7 @@ describe 'radio input' do
   describe "when :label option is false" do
     before do
       @output_buffer = ''
-      @new_post.stub!(:author_ids).and_return(nil)
+      @new_post.stub(:author_ids).and_return(nil)
       concat(semantic_form_for(@new_post) do |builder|
         concat(builder.input(:authors, :as => :radio, :label => false))
       end)
@@ -194,7 +194,7 @@ describe 'radio input' do
 
   describe "when :required option is true" do
     before do
-      @new_post.stub!(:author_ids).and_return(nil)
+      @new_post.stub(:author_ids).and_return(nil)
       concat(semantic_form_for(@new_post) do |builder|
         concat(builder.input(:authors, :as => :radio, :required => true))
       end)
@@ -208,7 +208,7 @@ describe 'radio input' do
   describe "when :namespace is given on form" do
     before do
       @output_buffer = ''
-      @new_post.stub!(:author_ids).and_return(nil)
+      @new_post.stub(:author_ids).and_return(nil)
       concat(semantic_form_for(@new_post, :namespace => "custom_prefix") do |builder|
         concat(builder.input(:authors, :as => :radio, :label => ''))
       end)

--- a/spec/inputs/range_input_spec.rb
+++ b/spec/inputs/range_input_spec.rb
@@ -74,7 +74,7 @@ describe 'range input' do
 
   describe "when validations require a minimum value (:greater_than)" do
     before do
-      @new_post.class.stub!(:validators_on).with(:title).and_return([
+      @new_post.class.stub(:validators_on).with(:title).and_return([
         active_model_numericality_validator([:title], {:only_integer=>false, :allow_nil=>false, :greater_than=>2})
       ])
     end
@@ -109,7 +109,7 @@ describe 'range input' do
 
     describe "and the column is an integer" do
       before do
-        @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :integer))
+        @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :integer))
       end
 
       it "should add a min attribute to the input one greater than the validation" do
@@ -122,7 +122,7 @@ describe 'range input' do
 
     describe "and the column is a float" do
       before do
-        @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :float))
+        @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :float))
       end
 
       it "should raise an error" do
@@ -136,7 +136,7 @@ describe 'range input' do
 
     describe "and the column is a big decimal" do
       before do
-        @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :decimal))
+        @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :decimal))
       end
 
       it "should raise an error" do
@@ -152,7 +152,7 @@ describe 'range input' do
 
   describe "when validations require a minimum value (:greater_than_or_equal_to)" do
     before do
-      @new_post.class.stub!(:validators_on).with(:title).and_return([
+      @new_post.class.stub(:validators_on).with(:title).and_return([
         active_model_numericality_validator([:title], {:only_integer=>false, :allow_nil=>false, :greater_than_or_equal_to=>2})
       ])
     end
@@ -189,7 +189,7 @@ describe 'range input' do
     [:integer, :decimal, :float].each do |column_type|
       describe "and the column is a #{column_type}" do
         before do
-          @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => column_type))
+          @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => column_type))
         end
 
         it "should add a max attribute to the input equal to the validation" do
@@ -203,7 +203,7 @@ describe 'range input' do
 
     describe "and there is no column" do
       before do
-        @new_post.stub!(:column_for_attribute).with(:title).and_return(nil)
+        @new_post.stub(:column_for_attribute).with(:title).and_return(nil)
       end
 
       it "should add a max attribute to the input equal to the validation" do
@@ -228,7 +228,7 @@ describe 'range input' do
 
   describe "when validations require a maximum value (:less_than)" do
    before do
-     @new_post.class.stub!(:validators_on).with(:title).and_return([
+     @new_post.class.stub(:validators_on).with(:title).and_return([
        active_model_numericality_validator([:title], {:only_integer=>false, :allow_nil=>false, :less_than=>20})
      ])
    end
@@ -263,7 +263,7 @@ describe 'range input' do
 
    describe "and the column is an integer" do
      before do
-       @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :integer))
+       @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :integer))
      end
 
      it "should add a max attribute to the input one greater than the validation" do
@@ -276,7 +276,7 @@ describe 'range input' do
 
    describe "and the column is a float" do
      before do
-       @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :float))
+       @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :float))
      end
 
      it "should raise an error" do
@@ -290,7 +290,7 @@ describe 'range input' do
 
    describe "and the column is a big decimal" do
      before do
-       @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => :decimal))
+       @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => :decimal))
      end
 
      it "should raise an error" do
@@ -306,7 +306,7 @@ describe 'range input' do
 
   describe "when validations require a maximum value (:less_than_or_equal_to)" do
     before do
-      @new_post.class.stub!(:validators_on).with(:title).and_return([
+      @new_post.class.stub(:validators_on).with(:title).and_return([
         active_model_numericality_validator([:title], {:only_integer=>false, :allow_nil=>false, :less_than_or_equal_to=>20})
       ])
     end
@@ -342,7 +342,7 @@ describe 'range input' do
     [:integer, :decimal, :float].each do |column_type|
       describe "and the column is a #{column_type}" do
         before do
-          @new_post.stub!(:column_for_attribute).with(:title).and_return(mock('column', :type => column_type))
+          @new_post.stub(:column_for_attribute).with(:title).and_return(double('column', :type => column_type))
         end
 
         it "should add a max attribute to the input equal to the validation" do
@@ -356,7 +356,7 @@ describe 'range input' do
 
     describe "and there is no column" do
       before do
-        @new_post.stub!(:column_for_attribute).with(:title).and_return(nil)
+        @new_post.stub(:column_for_attribute).with(:title).and_return(nil)
       end
 
       it "should add a max attribute to the input equal to the validation" do
@@ -381,7 +381,7 @@ describe 'range input' do
 
   describe "when validations require conflicting minimum values (:greater_than, :greater_than_or_equal_to)" do
     before do
-      @new_post.class.stub!(:validators_on).with(:title).and_return([
+      @new_post.class.stub(:validators_on).with(:title).and_return([
         active_model_numericality_validator([:title], {:only_integer=>false, :allow_nil=>false, :greater_than => 20, :greater_than_or_equal_to=>2})
       ])
     end
@@ -396,7 +396,7 @@ describe 'range input' do
 
   describe "when validations require conflicting maximum values (:less_than, :less_than_or_equal_to)" do
     before do
-      @new_post.class.stub!(:validators_on).with(:title).and_return([
+      @new_post.class.stub(:validators_on).with(:title).and_return([
         active_model_numericality_validator([:title], {:only_integer=>false, :allow_nil=>false, :less_than => 20, :less_than_or_equal_to=>2})
       ])
     end
@@ -412,7 +412,7 @@ describe 'range input' do
   describe "when validations require only an integer (:only_integer)" do
 
     before do
-      @new_post.class.stub!(:validators_on).with(:title).and_return([
+      @new_post.class.stub(:validators_on).with(:title).and_return([
         active_model_numericality_validator([:title], {:allow_nil=>false, :only_integer=>true})
       ])
     end
@@ -443,7 +443,7 @@ describe 'range input' do
   describe "when validations require a :step (non standard)" do
 
     before do
-      @new_post.class.stub!(:validators_on).with(:title).and_return([
+      @new_post.class.stub(:validators_on).with(:title).and_return([
         active_model_numericality_validator([:title], {:allow_nil=>false, :only_integer=>true, :step=>2})
       ])
     end
@@ -474,7 +474,7 @@ describe 'range input' do
   describe "when validations do not specify :step (non standard) or :only_integer" do
 
     before do
-      @new_post.class.stub!(:validators_on).with(:title).and_return([
+      @new_post.class.stub(:validators_on).with(:title).and_return([
         active_model_numericality_validator([:title], {:allow_nil=>false})
       ])
     end

--- a/spec/inputs/select_input_spec.rb
+++ b/spec/inputs/select_input_spec.rb
@@ -205,21 +205,6 @@ describe 'select input' do
     end
   end
 
-  describe "for a belongs_to association with :group_by => :author" do
-    it "should call author.posts" do
-      ::Author.stub(:reflect_on_all_associations).and_return { |macro| macro == :has_many ? [double('reflection', :klass => Post, :name => :posts)] : []}
-
-      [@freds_post].each { |post| post.stub(:to_label).and_return("Post - #{post.id}") }
-      @fred.should_receive(:posts)
-
-      with_deprecation_silenced do
-        concat(semantic_form_for(@new_post) do |builder|
-          concat(builder.input(:main_post, :as => :select, :group_by => :author ) )
-        end)
-      end
-    end
-  end
-
   describe "for a belongs_to association with :conditions" do
     before do
       ::Post.stub(:reflect_on_association).with(:author).and_return do

--- a/spec/inputs/select_input_spec.rb
+++ b/spec/inputs/select_input_spec.rb
@@ -33,7 +33,7 @@ describe 'select input' do
 
     describe "using a related model without reflection's options (Mongoid Document)" do
       before do
-        @new_post.stub!(:mongoid_reviewer)
+        @new_post.stub(:mongoid_reviewer)
         concat(semantic_form_for(@new_post) do |builder|
           concat(builder.input(:mongoid_reviewer, :as => :select))
         end)
@@ -88,7 +88,7 @@ describe 'select input' do
   end
 
   describe 'for boolean columns' do
-    pending
+    skip
     # describe 'default formtastic locale' do
     #   before do
     #     # Note: Works, but something like Formtastic.root.join(...) would probably be "safer".
@@ -193,9 +193,9 @@ describe 'select input' do
     end
 
     it 'should not singularize the association name' do
-      @new_post.stub!(:author_status).and_return(@bob)
-      @new_post.stub!(:author_status_id).and_return(@bob.id)
-      @new_post.stub!(:column_for_attribute).and_return(mock('column', :type => :integer, :limit => 255))
+      @new_post.stub(:author_status).and_return(@bob)
+      @new_post.stub(:author_status_id).and_return(@bob.id)
+      @new_post.stub(:column_for_attribute).and_return(double('column', :type => :integer, :limit => 255))
 
       concat(semantic_form_for(@new_post) do |builder|
         concat(builder.input(:author_status, :as => :select))
@@ -207,9 +207,9 @@ describe 'select input' do
 
   describe "for a belongs_to association with :group_by => :author" do
     it "should call author.posts" do
-      ::Author.stub!(:reflect_on_all_associations).and_return { |macro| macro == :has_many ? [mock('reflection', :klass => Post, :name => :posts)] : []}
+      ::Author.stub(:reflect_on_all_associations).and_return { |macro| macro == :has_many ? [double('reflection', :klass => Post, :name => :posts)] : []}
 
-      [@freds_post].each { |post| post.stub!(:to_label).and_return("Post - #{post.id}") }
+      [@freds_post].each { |post| post.stub(:to_label).and_return("Post - #{post.id}") }
       @fred.should_receive(:posts)
 
       with_deprecation_silenced do
@@ -222,9 +222,9 @@ describe 'select input' do
 
   describe "for a belongs_to association with :conditions" do
     before do
-      ::Post.stub!(:reflect_on_association).with(:author).and_return do
-        mock = mock('reflection', :options => {:conditions => {:active => true}}, :klass => ::Author, :macro => :belongs_to)
-        mock.stub!(:[]).with(:class_name).and_return("Author")
+      ::Post.stub(:reflect_on_association).with(:author).and_return do
+        mock = double('reflection', :options => {:conditions => {:active => true}}, :klass => ::Author, :macro => :belongs_to)
+        mock.stub(:[]).with(:class_name).and_return("Author")
         mock
       end
     end
@@ -252,19 +252,19 @@ describe 'select input' do
   describe 'for a belongs_to association with :group_by => :continent' do
     before do
       @authors = [@bob, @fred, @fred, @fred]
-      ::Author.stub!(:find).and_return(@authors)
+      ::Author.stub(:find).and_return(@authors)
       @continent_names = %w(Europe Africa)
-      @continents = (0..1).map { |i| c = ::Continent.new; c.stub!(:id).and_return(100 - i);c }
-      @authors[0..1].each_with_index { |author, i| author.stub!(:continent).and_return(@continents[i]) }
+      @continents = (0..1).map { |i| c = ::Continent.new; c.stub(:id).and_return(100 - i);c }
+      @authors[0..1].each_with_index { |author, i| author.stub(:continent).and_return(@continents[i]) }
 
-      ::Continent.stub!(:reflect_on_all_associations).and_return { |macro| macro == :has_many ? [mock('reflection', :klass => Author, :name => :authors)] : [] }
-      ::Continent.stub!(:reflect_on_association).and_return {|column_name| mock('reflection', :klass => Author) if column_name == :authors}
-      ::Author.stub!(:reflect_on_association).and_return { |column_name| mock('reflection', :options => {}, :klass => Continent, :macro => :belongs_to) if column_name == :continent }
+      ::Continent.stub(:reflect_on_all_associations).and_return { |macro| macro == :has_many ? [double('reflection', :klass => Author, :name => :authors)] : [] }
+      ::Continent.stub(:reflect_on_association).and_return {|column_name| double('reflection', :klass => Author) if column_name == :authors}
+      ::Author.stub(:reflect_on_association).and_return { |column_name| double('reflection', :options => {}, :klass => Continent, :macro => :belongs_to) if column_name == :continent }
 
 
       @continents.each_with_index do |continent, i|
-        continent.stub!(:to_label).and_return(@continent_names[i])
-        continent.stub!(:authors).and_return([@authors[i]])
+        continent.stub(:to_label).and_return(@continent_names[i])
+        continent.stub(:authors).and_return([@authors[i]])
       end
 
       with_deprecation_silenced do
@@ -444,7 +444,7 @@ describe 'select input' do
 
   describe 'when :prompt => "choose something" is set' do
     before do
-      @new_post.stub!(:author_id).and_return(nil)
+      @new_post.stub(:author_id).and_return(nil)
       concat(semantic_form_for(@new_post) do |builder|
         concat(builder.input(:author, :as => :select, :prompt => "choose author"))
       end)
@@ -537,7 +537,7 @@ describe 'select input' do
     before do
       @output_buffer = ''
       @some_meta_descriptions = ["One", "Two", "Three"]
-      @new_post.stub!(:meta_description).any_number_of_times
+      @new_post.stub(:meta_description).any_number_of_times
     end
 
     describe ":as is not set" do

--- a/spec/inputs/string_input_spec.rb
+++ b/spec/inputs/string_input_spec.rb
@@ -46,11 +46,11 @@ describe 'string input' do
       let(:default_maxlength) { 50 }
 
       before do
-        @new_post.stub!(:class).and_return(::PostModel)
+        @new_post.stub(:class).and_return(::PostModel)
       end
 
       after do
-        @new_post.stub!(:class).and_return(::Post)
+        @new_post.stub(:class).and_return(::Post)
       end
 
       describe 'and validates_length_of was called for the method' do

--- a/spec/inputs/time_select_input_spec.rb
+++ b/spec/inputs/time_select_input_spec.rb
@@ -124,7 +124,7 @@ describe 'time select input' do
 
   describe ':labels option' do
     it "should provide a message that :labels is not supported" do
-      pending ':labels is not supported'
+      skip ':labels is not supported'
     end
   end
 

--- a/spec/support/custom_macros.rb
+++ b/spec/support/custom_macros.rb
@@ -162,7 +162,7 @@ module CustomMacros
     def it_should_use_column_size_for_columns_shorter_than_default_text_field_size(as)
       it 'should use the column size for columns shorter than default_text_field_size' do
         column_limit_shorted_than_default = 1
-        @new_post.stub!(:column_for_attribute).and_return(mock('column', :type => as, :limit => column_limit_shorted_than_default))
+        @new_post.stub(:column_for_attribute).and_return(double('column', :type => as, :limit => column_limit_shorted_than_default))
 
         concat(semantic_form_for(@new_post) do |builder|
           concat(builder.input(:title, :as => as))
@@ -176,12 +176,12 @@ module CustomMacros
       describe 'when there are errors on the object for this method' do
         before do
           @title_errors = ['must not be blank', 'must be longer than 10 characters', 'must be awesome']
-          @errors = mock('errors')
-          @errors.stub!(:[]).with(errors_matcher(:title)).and_return(@title_errors)
+          @errors = double('errors')
+          @errors.stub(:[]).with(errors_matcher(:title)).and_return(@title_errors)
           Formtastic::FormBuilder.file_metadata_suffixes.each do |suffix|
-            @errors.stub!(:[]).with(errors_matcher("title_#{suffix}".to_sym)).and_return(nil)
+            @errors.stub(:[]).with(errors_matcher("title_#{suffix}".to_sym)).and_return(nil)
           end
-          @new_post.stub!(:errors).and_return(@errors)
+          @new_post.stub(:errors).and_return(@errors)
         end
 
         it 'should apply an errors class to the list item' do
@@ -307,7 +307,7 @@ module CustomMacros
 
           if as == :radio
             it 'should generate a sanitized label for attribute' do
-              @bob.stub!(:category_name).and_return(@categories)
+              @bob.stub(:category_name).and_return(@categories)
               concat(semantic_form_for(@new_post) do |builder|
                 fields = builder.semantic_fields_for(@bob) do |bob_builder|
                   concat(bob_builder.input(:category_name, :as => as, :collection => @categories))
@@ -464,8 +464,8 @@ module CustomMacros
 
             describe "when the collection objects respond to #{label_method}" do
               before do
-                @fred.stub!(:respond_to?).and_return { |m| m.to_s == label_method || m.to_s == 'id' }
-                ::Author.all.each { |a| a.stub!(label_method).and_return('The Label Text') }
+                @fred.stub(:respond_to?).and_return { |m| m.to_s == label_method || m.to_s == 'id' }
+                ::Author.all.each { |a| a.stub(label_method).and_return('The Label Text') }
 
                 concat(semantic_form_for(@new_post) do |builder|
                   concat(builder.input(:author, :as => as))


### PR DESCRIPTION
Grouped Collections and the :group_by option were removed in Formtastic 3.1.  Work in process here to revise the select input to conform to formtastic 3.1.

TODO:
* Cleanup all select_input_spec
* Revise group_by specs to conform with formtastic 3.1 select interface https://github.com/justinfrench/formtastic/blob/3.1-stable/lib/formtastic/inputs/select_input.rb
* Decide what deprecation/release notes if any are needed - we may be able to push this responsibility onto the formtastic gem since it will no longer work with group_by