### PR TITLE
Choices/wrapper html options

### DIFF
--- a/lib/formtastic-bootstrap/inputs/check_boxes_input.rb
+++ b/lib/formtastic-bootstrap/inputs/check_boxes_input.rb
@@ -16,7 +16,7 @@ module FormtasticBootstrap
       end
 
       def choice_html(choice)
-        checkbox_wrapping do
+        checkbox_wrapping(choice) do
           template.content_tag(:label,
             hidden_fields? ?
               check_box_with_hidden_input(choice) :
@@ -27,15 +27,26 @@ module FormtasticBootstrap
         end
       end
 
-      def checkbox_wrapping(&block)
-        class_name = "checkbox"
-        class_name += " checkbox-inline" if options[:inline]
+      def checkbox_wrapping(choice, &block)
         template.content_tag(:div,
           template.capture(&block).html_safe,
-          :class => class_name
+          checkbox_wrapping_html_options(choice)
         )
       end
 
+      def checkbox_wrapping_html_options(choice)
+        class_name = "checkbox"
+        class_name += " checkbox-inline" if options[:inline]
+        { :class => class_name }.merge(custom_checkbox_wrapping_html_options choice)
+      end
+
+      def custom_checkbox_wrapping_html_options(choice)
+        if (choice.is_a?(Array) && choice.size > 2 && choice.last[:wrapper_html].present?)
+          choice.last[:wrapper_html]
+        else
+          {}
+        end
+      end
     end
   end
 end

--- a/lib/formtastic-bootstrap/inputs/radio_input.rb
+++ b/lib/formtastic-bootstrap/inputs/radio_input.rb
@@ -23,7 +23,7 @@ module FormtasticBootstrap
       end
 
       def choice_html(choice)
-        radio_wrapping do
+        radio_wrapping(choice) do
           template.content_tag(:label,
             builder.radio_button(input_name, choice_value(choice), input_html_options.merge(choice_html_options(choice)).merge(:required => false)) <<
             choice_label(choice),
@@ -32,16 +32,26 @@ module FormtasticBootstrap
         end
       end
 
-      def radio_wrapping(&block)
-        class_name = "radio"
-        class_name += " radio-inline" if options[:inline]
+      def radio_wrapping(choice, &block)
         template.content_tag(:div,
           template.capture(&block).html_safe,
-          :class => class_name
+          radio_wrapping_html_options(choice)
         )
       end
 
+      def radio_wrapping_html_options(choice)
+        class_name = "radio"
+        class_name += " radio-inline" if options[:inline]
+        { :class => class_name }.merge(custom_radio_wrapping_html_options choice)
+      end
+
+      def custom_radio_wrapping_html_options(choice)
+        if (choice.is_a?(Array) && choice.size > 2 && choice.last[:wrapper_html].present?)
+          choice.last[:wrapper_html]
+        else
+          {}
+        end
+      end
     end
   end
 end
-

--- a/spec/inputs/check_boxes_input_spec.rb
+++ b/spec/inputs/check_boxes_input_spec.rb
@@ -442,5 +442,26 @@ describe 'check_boxes input' do
     end
   end
 
-end
+  describe 'when collection contain wrapper_html' do
+    let(:collection) do
+      [
+        [ 'Foo', 1, { :wrapper_html => { 'data-id' => 1 } } ],
+        [ 'Bar', 2, { :wrapper_html => { 'data-id' => 2 } } ]
+      ]
+    end
 
+    before do
+      @output_buffer = ''
+      mock_everything
+
+      concat(semantic_form_for(:project) do |builder|
+        concat(builder.input(:author_id, :as => :check_boxes, :collection => collection))
+      end)
+    end
+
+    it 'should output the correct labels' do
+      output_buffer.should have_tag('span.form-wrapper div.checkbox[@data-id="1"]')
+      output_buffer.should have_tag('span.form-wrapper div.checkbox[@data-id="2"]')
+    end
+  end
+end

--- a/spec/inputs/radio_input_spec.rb
+++ b/spec/inputs/radio_input_spec.rb
@@ -264,4 +264,26 @@ describe 'radio input' do
     end
   end
 
+  describe 'when collection contain wrapper_html' do
+    let(:collection) do
+      [
+        [ 'Foo', 1, { :wrapper_html => { 'data-id' => 1 } } ],
+        [ 'Bar', 2, { :wrapper_html => { 'data-id' => 2 } } ]
+      ]
+    end
+
+    before do
+      @output_buffer = ''
+      mock_everything
+
+      concat(semantic_form_for(:project) do |builder|
+        concat(builder.input(:author_id, :as => :radio, :collection => collection))
+      end)
+    end
+
+    it 'should output the correct labels' do
+      output_buffer.should have_tag('span.form-wrapper div.radio[@data-id="1"]')
+      output_buffer.should have_tag('span.form-wrapper div.radio[@data-id="2"]')
+    end
+  end
 end


### PR DESCRIPTION
Add `wrapper_html` option to Checkboxes and Radio buttons, to allow change markup of input wrappers.

Usage:

``` ruby
f.input :author, :as => :radio, :collection => [
  ["Test", 'test'],
  ["Try", "try", { :wrapper_html => { 'data-id' => 99 } }]
]
```
